### PR TITLE
[ADDED] Battery monitor using copilot

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/monitor/BatteryMonitor.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/monitor/BatteryMonitor.kt
@@ -1,0 +1,26 @@
+package dev.hossain.remotenotify.monitor
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.BatteryManager
+
+class BatteryMonitor(
+    private val context: Context,
+) {
+    fun getBatteryLevel(): Int {
+        val batteryIntent: Intent? = context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        val level = batteryIntent?.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) ?: -1
+        val scale = batteryIntent?.getIntExtra(BatteryManager.EXTRA_SCALE, -1) ?: -1
+        return if (level >= 0 && scale > 0) (level * 100) / scale else -1
+    }
+
+    fun registerBatteryLevelReceiver(receiver: BroadcastReceiver) {
+        context.registerReceiver(receiver, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+    }
+
+    fun unregisterBatteryLevelReceiver(receiver: BroadcastReceiver) {
+        context.unregisterReceiver(receiver)
+    }
+}

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
@@ -35,6 +36,7 @@ import dagger.assisted.AssistedInject
 import dev.hossain.remotenotify.data.RemoteAlertRepository
 import dev.hossain.remotenotify.di.AppScope
 import dev.hossain.remotenotify.model.RemoteNotification
+import dev.hossain.remotenotify.monitor.BatteryMonitor
 import dev.hossain.remotenotify.ui.addalert.AddNewRemoteAlertScreen
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
@@ -102,6 +104,9 @@ fun AlertsListUi(
     state: AlertsListScreen.State,
     modifier: Modifier = Modifier,
 ) {
+    val batteryMonitor = BatteryMonitor(LocalContext.current)
+    val batteryPercentage = batteryMonitor.getBatteryLevel()
+
     Scaffold(
         modifier = modifier,
         floatingActionButton = {
@@ -110,11 +115,18 @@ fun AlertsListUi(
             }
         },
     ) { innerPadding ->
-        LazyColumn(modifier = Modifier.padding(innerPadding)) {
-            items(state.notifications) { notification ->
-                NotificationItem(notification = notification, onDelete = {
-                    state.eventSink(AlertsListScreen.Event.DeleteNotification(notification))
-                })
+        Column(modifier = Modifier.padding(innerPadding)) {
+            // Display battery percentage at the top
+            Text(
+                text = "Battery Percentage: $batteryPercentage%",
+                modifier = Modifier.padding(16.dp),
+            )
+            LazyColumn {
+                items(state.notifications) { notification ->
+                    NotificationItem(notification = notification, onDelete = {
+                        state.eventSink(AlertsListScreen.Event.DeleteNotification(notification))
+                    })
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #20

https://github.com/hossain-khan/android-remote-notify/issues/3#issuecomment-2646426553

This pull request introduces a new `BatteryMonitor` class to monitor battery levels and integrates this functionality into the `AlertsListScreen` UI. The most important changes include the creation of the `BatteryMonitor` class, importing necessary dependencies, and updating the UI to display the battery percentage.

### Battery Monitoring:

* [`app/src/main/java/dev/hossain/remotenotify/monitor/BatteryMonitor.kt`](diffhunk://#diff-016aeae6db3a81b2840777515ab4c44a2121ebca47eff004d582d4aec225e0fcR1-R26): Added a new `BatteryMonitor` class to get the battery level and manage battery level receivers.

### UI Updates:

* [`app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt`](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577R24): Imported `LocalContext` and `BatteryMonitor` to use the new battery monitoring functionality. [[1]](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577R24) [[2]](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577R39)
* [`app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt`](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577R107-R109): Instantiated `BatteryMonitor` and retrieved the battery percentage in the `AlertsListUi` function.
* [`app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt`](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577L113-R124): Updated the UI to display the battery percentage at the top of the screen. [[1]](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577L113-R124) [[2]](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577R133)