### PR TITLE
[ADDED] Storage monitor

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/monitor/StorageMonitor.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/monitor/StorageMonitor.kt
@@ -1,0 +1,18 @@
+package dev.hossain.remotenotify.monitor
+
+import android.os.Environment
+import android.os.StatFs
+
+class StorageMonitor {
+    fun getAvailableStorageInGB(): Long {
+        val stat = StatFs(Environment.getExternalStorageDirectory().path)
+        val bytesAvailable = stat.blockSizeLong * stat.availableBlocksLong
+        return bytesAvailable / (1024 * 1024 * 1024) // Convert to GB
+    }
+
+    fun getTotalStorageInGB(): Long {
+        val stat = StatFs(Environment.getExternalStorageDirectory().path)
+        val bytesTotal = stat.blockSizeLong * stat.blockCountLong
+        return bytesTotal / (1024 * 1024 * 1024) // Convert to GB
+    }
+}

--- a/app/src/main/java/dev/hossain/remotenotify/monitor/StorageMonitor.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/monitor/StorageMonitor.kt
@@ -1,18 +1,43 @@
 package dev.hossain.remotenotify.monitor
 
+import android.app.usage.StorageStatsManager
+import android.content.Context
 import android.os.Environment
 import android.os.StatFs
+import android.os.storage.StorageManager
+import androidx.core.content.ContextCompat
+import java.util.UUID
 
-class StorageMonitor {
-    fun getAvailableStorageInGB(): Long {
+class StorageMonitor(
+    private val context: Context,
+) {
+    fun getAvailableStorageInGBStatFs(): Long {
         val stat = StatFs(Environment.getExternalStorageDirectory().path)
         val bytesAvailable = stat.blockSizeLong * stat.availableBlocksLong
         return bytesAvailable / (1024 * 1024 * 1024) // Convert to GB
     }
 
-    fun getTotalStorageInGB(): Long {
+    fun getTotalStorageInGBStatFs(): Long {
         val stat = StatFs(Environment.getExternalStorageDirectory().path)
         val bytesTotal = stat.blockSizeLong * stat.blockCountLong
+        return bytesTotal / (1024 * 1024 * 1024) // Convert to GB
+    }
+
+    fun getAvailableStorageInGB(): Long {
+        val storageStatsManager = ContextCompat.getSystemService(context, StorageStatsManager::class.java)!!
+        val storageManager = ContextCompat.getSystemService(context, StorageManager::class.java)!!
+        val storageVolume = storageManager.primaryStorageVolume
+        val uuid = storageVolume.uuid?.let { UUID.fromString(it) } ?: StorageManager.UUID_DEFAULT
+        val bytesAvailable = storageStatsManager.getFreeBytes(uuid)
+        return bytesAvailable / (1024 * 1024 * 1024) // Convert to GB
+    }
+
+    fun getTotalStorageInGB(): Long {
+        val storageStatsManager = ContextCompat.getSystemService(context, StorageStatsManager::class.java)!!
+        val storageManager = ContextCompat.getSystemService(context, StorageManager::class.java)!!
+        val storageVolume = storageManager.primaryStorageVolume
+        val uuid = storageVolume.uuid?.let { UUID.fromString(it) } ?: StorageManager.UUID_DEFAULT
+        val bytesTotal = storageStatsManager.getTotalBytes(uuid)
         return bytesTotal / (1024 * 1024 * 1024) // Convert to GB
     }
 }

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
@@ -107,7 +107,7 @@ fun AlertsListUi(
 ) {
     val context = LocalContext.current
     val batteryMonitor = BatteryMonitor(context)
-    val storageMonitor = StorageMonitor()
+    val storageMonitor = StorageMonitor(context)
     val batteryPercentage = batteryMonitor.getBatteryLevel()
     val availableStorage = storageMonitor.getAvailableStorageInGB()
     val totalStorage = storageMonitor.getTotalStorageInGB()

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
@@ -37,6 +37,7 @@ import dev.hossain.remotenotify.data.RemoteAlertRepository
 import dev.hossain.remotenotify.di.AppScope
 import dev.hossain.remotenotify.model.RemoteNotification
 import dev.hossain.remotenotify.monitor.BatteryMonitor
+import dev.hossain.remotenotify.monitor.StorageMonitor
 import dev.hossain.remotenotify.ui.addalert.AddNewRemoteAlertScreen
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
@@ -104,8 +105,12 @@ fun AlertsListUi(
     state: AlertsListScreen.State,
     modifier: Modifier = Modifier,
 ) {
-    val batteryMonitor = BatteryMonitor(LocalContext.current)
+    val context = LocalContext.current
+    val batteryMonitor = BatteryMonitor(context)
+    val storageMonitor = StorageMonitor()
     val batteryPercentage = batteryMonitor.getBatteryLevel()
+    val availableStorage = storageMonitor.getAvailableStorageInGB()
+    val totalStorage = storageMonitor.getTotalStorageInGB()
 
     Scaffold(
         modifier = modifier,
@@ -119,7 +124,16 @@ fun AlertsListUi(
             // Display battery percentage at the top
             Text(
                 text = "Battery Percentage: $batteryPercentage%",
-                modifier = Modifier.padding(16.dp),
+                modifier = Modifier.padding(2.dp),
+            )
+            // Display storage data under battery level
+            Text(
+                text = "Available Storage: $availableStorage GB",
+                modifier = Modifier.padding(2.dp),
+            )
+            Text(
+                text = "Total Storage: $totalStorage GB",
+                modifier = Modifier.padding(2.dp),
             )
             LazyColumn {
                 items(state.notifications) { notification ->


### PR DESCRIPTION
Fixes #21

This pull request introduces a new `StorageMonitor` class to monitor storage statistics and integrates it into the `AlertsListScreen` to display storage information alongside battery percentage. The most important changes include the creation of the `StorageMonitor` class, updates to the `AlertsListScreen` to use the new class, and modifications to the UI to display storage data.

### Storage Monitoring Implementation:

* [`app/src/main/java/dev/hossain/remotenotify/monitor/StorageMonitor.kt`](diffhunk://#diff-0a6ab6f5222cf507e9d0108764e19bfbc5a162dbaf743d97a0a03bb3226178b9R1-R43): Added a new `StorageMonitor` class to monitor available and total storage using both `StatFs` and `StorageStatsManager`.

### Integration into Alerts List Screen:

* [`app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt`](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577R40): Imported the `StorageMonitor` class and created an instance of it in the `AlertsListUi` function. [[1]](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577R40) [[2]](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577L107-R113)

### UI Updates:

* [`app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt`](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577L122-R136): Modified the UI to display available and total storage in GB alongside the battery percentage.