### PR TITLE
[FIXED] Save token pef compose screen

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/data/TelegramConfigDataStore.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/TelegramConfigDataStore.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import dev.hossain.remotenotify.di.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import timber.log.Timber
 import javax.inject.Inject
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "telegram_config")
@@ -26,22 +27,24 @@ class TelegramConfigDataStore
         val botToken: Flow<String?> =
             context.dataStore.data
                 .map { preferences ->
-                    preferences[BOT_TOKEN_KEY]
+                    preferences[BOT_TOKEN_KEY] ?: "WHICH-BOT?"
                 }
 
         val chatId: Flow<String?> =
             context.dataStore.data
                 .map { preferences ->
-                    preferences[CHAT_ID_KEY]
+                    preferences[CHAT_ID_KEY] ?: "WHICH-CHAT-ID?"
                 }
 
         suspend fun saveBotToken(botToken: String) {
+            Timber.d("Saving bot token: $botToken")
             context.dataStore.edit { preferences ->
                 preferences[BOT_TOKEN_KEY] = botToken
             }
         }
 
         suspend fun saveChatId(chatId: String) {
+            Timber.d("Saving chat id: $chatId")
             context.dataStore.edit { preferences ->
                 preferences[CHAT_ID_KEY] = chatId
             }


### PR DESCRIPTION
This pull request includes several changes to improve logging, handle default values, and refactor event handling in the `TelegramConfigDataStore` and `AddNotificationMediumScreen` classes.

### Logging Improvements:
* Added `Timber` logging to log messages when saving bot tokens and chat IDs in `TelegramConfigDataStore`. [[1]](diffhunk://#diff-e14ec39286872cefac09b71989cf8e0c7e4570e28de4f33925b639ffc21ad3d7R12) [[2]](diffhunk://#diff-e14ec39286872cefac09b71989cf8e0c7e4570e28de4f33925b639ffc21ad3d7L29-R47)
* Imported `Timber` in `AddNotificationMediumScreen` for logging purposes.

### Default Value Handling:
* Updated `TelegramConfigDataStore` to provide default values for bot token and chat ID if they are not present in the preferences.

### Event Handling Refactoring:
* Refactored `AddNotificationMediumScreen` to use new event types `OnBotTokenUpdated` and `OnChatIdUpdated` instead of passing values directly in `SaveTelegramConfig`. [[1]](diffhunk://#diff-d6c047a0c269bc1f196d2619ccc09e682ab0e3bbc4e67d3b6d41f5fe6f8553feL45-R52) [[2]](diffhunk://#diff-d6c047a0c269bc1f196d2619ccc09e682ab0e3bbc4e67d3b6d41f5fe6f8553feL73-R96)
* Updated UI to handle new event types for bot token and chat ID changes. [[1]](diffhunk://#diff-d6c047a0c269bc1f196d2619ccc09e682ab0e3bbc4e67d3b6d41f5fe6f8553feL96-L97) [[2]](diffhunk://#diff-d6c047a0c269bc1f196d2619ccc09e682ab0e3bbc4e67d3b6d41f5fe6f8553feL123-R164)