### PR TITLE
Worker cleanup

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/RemoteAlertApp.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/RemoteAlertApp.kt
@@ -33,11 +33,10 @@ class RemoteAlertApp :
 
     override fun onCreate() {
         super.onCreate()
+        installLoggingTree()
         appComponent.inject(this)
 
-        installLoggingTree()
-
-        // TEST CODE
+        // TEST WORKER CODE
         // sendOneTimeWorkRequest(this)
     }
 

--- a/app/src/main/java/dev/hossain/remotenotify/data/TelegramConfigDataStore.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/TelegramConfigDataStore.kt
@@ -27,13 +27,13 @@ class TelegramConfigDataStore
         val botToken: Flow<String?> =
             context.dataStore.data
                 .map { preferences ->
-                    preferences[BOT_TOKEN_KEY] ?: "WHICH-BOT?"
+                    preferences[BOT_TOKEN_KEY]
                 }
 
         val chatId: Flow<String?> =
             context.dataStore.data
                 .map { preferences ->
-                    preferences[CHAT_ID_KEY] ?: "WHICH-CHAT-ID?"
+                    preferences[CHAT_ID_KEY]
                 }
 
         suspend fun saveBotToken(botToken: String) {

--- a/app/src/main/java/dev/hossain/remotenotify/di/NetworkModule.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/di/NetworkModule.kt
@@ -1,25 +1,16 @@
 package dev.hossain.remotenotify.di
 
-import android.content.Context
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
-import okhttp3.Cache
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
-import java.io.File
 
 @Module
 @ContributesTo(AppScope::class)
 object NetworkModule {
     @Provides
-    fun provideOkHttpClient(
-        @ApplicationContext context: Context,
-    ): OkHttpClient {
-        val cacheSize = 10 * 1024 * 1024 // 10 MB
-        val cacheDir = File(context.cacheDir, "http_cache")
-        val cache = Cache(cacheDir, cacheSize.toLong())
-
+    fun provideOkHttpClient(): OkHttpClient {
         val loggingInterceptor =
             HttpLoggingInterceptor().apply {
                 level = HttpLoggingInterceptor.Level.BODY
@@ -27,7 +18,6 @@ object NetworkModule {
 
         return OkHttpClient
             .Builder()
-            .cache(cache)
             .addInterceptor(loggingInterceptor)
             .build()
     }

--- a/app/src/main/java/dev/hossain/remotenotify/notifier/NotificationSender.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/notifier/NotificationSender.kt
@@ -8,7 +8,10 @@ import dev.hossain.remotenotify.model.RemoteNotification
 interface NotificationSender {
     val notifierType: NotifierType
 
-    suspend fun sendNotification(remoteNotification: RemoteNotification)
+    /**
+     * Sends remote notification and provides result as boolean representing success or failure
+     */
+    suspend fun sendNotification(remoteNotification: RemoteNotification): Boolean
 
     /**
      * Checks if all the required configuration is set for the notifier.

--- a/app/src/main/java/dev/hossain/remotenotify/notifier/TelegramNotificationSender.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/notifier/TelegramNotificationSender.kt
@@ -19,7 +19,7 @@ class TelegramNotificationSender
     @Inject
     constructor(
         private val telegramConfigDataStore: TelegramConfigDataStore,
-        private val client: OkHttpClient,
+        private val okHttpClient: OkHttpClient,
     ) : NotificationSender {
         override val notifierType: NotifierType = NotifierType.TELEGRAM
 
@@ -56,7 +56,7 @@ class TelegramNotificationSender
                     .post(body)
                     .build()
 
-            client.newCall(request).execute().use { response ->
+            okHttpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
                     Timber.e("Failed to send notification: ${response.code} - ${response.message}")
                 } else {
@@ -73,6 +73,7 @@ class TelegramNotificationSender
                 Timber.e("Bot token or chat ID is not configured.")
                 return false
             } else {
+                Timber.i("Telegram config is set correctly.")
                 return true
             }
         }

--- a/app/src/main/java/dev/hossain/remotenotify/notifier/TelegramNotificationSender.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/notifier/TelegramNotificationSender.kt
@@ -23,7 +23,7 @@ class TelegramNotificationSender
     ) : NotificationSender {
         override val notifierType: NotifierType = NotifierType.TELEGRAM
 
-        override suspend fun sendNotification(remoteNotification: RemoteNotification) {
+        override suspend fun sendNotification(remoteNotification: RemoteNotification): Boolean {
             val message =
                 when (remoteNotification) {
                     is RemoteNotification.BatteryNotification -> "Battery Alert: ${remoteNotification.batteryPercentage}%"
@@ -59,8 +59,10 @@ class TelegramNotificationSender
             okHttpClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
                     Timber.e("Failed to send notification: ${response.code} - ${response.message}")
+                    return false
                 } else {
                     Timber.d("Notification sent successfully: $message")
+                    return true
                 }
             }
         }

--- a/app/src/main/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorker.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorker.kt
@@ -24,7 +24,7 @@ class ObserveDeviceHealthWorker(
     private val notifiers: Set<@JvmSuppressWildcards NotificationSender>,
 ) : CoroutineWorker(context, workerParams) {
     companion object {
-        private const val WORKER_LOG_TAG = "RAWorker"
+        private const val WORKER_LOG_TAG = "RA-Worker"
     }
 
     override suspend fun doWork(): Result =
@@ -58,6 +58,11 @@ class ObserveDeviceHealthWorker(
         }
 
     private suspend fun sendNotification(notification: RemoteNotification) {
+        if (notifiers.isEmpty()) {
+            // This should ideally not happen unless dagger setup has failed
+            Timber.e("No remote notifier has been registered")
+        }
+
         notifiers
             .filter { it.hasValidConfiguration() }
             .forEach { notifier ->

--- a/app/src/main/java/dev/hossain/remotenotify/worker/WorkerRequest.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/worker/WorkerRequest.kt
@@ -1,6 +1,8 @@
 package dev.hossain.remotenotify.worker
 
 import android.content.Context
+import androidx.work.Constraints
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkRequest
@@ -8,7 +10,14 @@ import androidx.work.WorkRequest
 fun sendOneTimeWorkRequest(context: Context) {
     val workRequest: WorkRequest =
         OneTimeWorkRequestBuilder<ObserveDeviceHealthWorker>()
-            .addTag("onetime-test-request")
+            .setConstraints(
+                Constraints
+                    .Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .setRequiresBatteryNotLow(true)
+                    .setRequiresStorageNotLow(true)
+                    .build(),
+            ).addTag("onetime-test-request")
             .build()
 
     WorkManager.getInstance(context).enqueue(workRequest)


### PR DESCRIPTION
This pull request includes several changes to improve logging, simplify code, and enhance functionality. The most important changes include adding detailed logging, modifying method signatures, and updating network constraints.

Improvements to logging:

* [`app/src/main/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorker.kt`](diffhunk://#diff-5ee689a1381aac1d7479b5b8c7766435e0973569eb8f48394bbec5b2a8c2d4a2L27-R89): Added detailed logging for worker start, loaded alerts, battery level, available storage, and notification sending status.
* [`app/src/main/java/dev/hossain/remotenotify/notifier/TelegramNotificationSender.kt`](diffhunk://#diff-9abc0b15cf281cea137367d97a633a8170b0075994048d1f7001ba55dfbd8e89R78): Added logging to indicate when the Telegram configuration is set correctly and the result of sending notifications. [[1]](diffhunk://#diff-9abc0b15cf281cea137367d97a633a8170b0075994048d1f7001ba55dfbd8e89R78) [[2]](diffhunk://#diff-9abc0b15cf281cea137367d97a633a8170b0075994048d1f7001ba55dfbd8e89L59-R65)

Code simplification and refactoring:

* [`app/src/main/java/dev/hossain/remotenotify/di/NetworkModule.kt`](diffhunk://#diff-a2e14371cd5b5fd8c58209b3101be49b5302bb90676164c9233c19314bc6f19aL3-L30): Simplified the `provideOkHttpClient` method by removing the cache configuration.
* [`app/src/main/java/dev/hossain/remotenotify/notifier/TelegramNotificationSender.kt`](diffhunk://#diff-9abc0b15cf281cea137367d97a633a8170b0075994048d1f7001ba55dfbd8e89L22-R26): Changed the parameter name from `client` to `okHttpClient` for clarity.

Enhanced functionality:

* [`app/src/main/java/dev/hossain/remotenotify/notifier/NotificationSender.kt`](diffhunk://#diff-293682ae0140f57d2e4eb8eb5512c785ac0731e7f715c3a98ca980c0b28e5d2aL11-R14): Modified `sendNotification` method to return a boolean indicating success or failure.
* [`app/src/main/java/dev/hossain/remotenotify/worker/WorkerRequest.kt`](diffhunk://#diff-7440caa9b34ba8f1e0dfec205da017b988a56111229e7909b9314657ae1e3110R4-R20): Added network constraints to the one-time work request to ensure it only runs when connected to a network, with sufficient battery and storage.