### PR TITLE
[REFACTOR] Moved BL out of UI - added to state

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
@@ -104,6 +104,7 @@ class AlertsListPresenter
                             remoteAlertRepository.deleteRemoteNotification(event.notification)
                         }
                     }
+
                     AlertsListScreen.Event.AddNotification -> {
                         navigator.goTo(AddNewRemoteAlertScreen)
                     }
@@ -154,22 +155,15 @@ fun AlertsListUi(
             )
         },
     ) { innerPadding ->
-        Column(modifier = Modifier.padding(innerPadding).padding(horizontal = 16.dp)) {
-            // Display battery percentage at the top
-            Text(
-                text = "Battery Percentage: ${state.batteryPercentage}%",
-                modifier = Modifier.padding(2.dp),
-            )
-            // Display storage data under battery level
-            Text(
-                text = "Available Storage: ${state.availableStorage} GB",
-                modifier = Modifier.padding(2.dp),
-            )
-            Text(
-                text = "Total Storage: ${state.totalStorage} GB",
-                modifier = Modifier.padding(2.dp),
-            )
+        Column(
+            modifier =
+                Modifier
+                    .padding(innerPadding)
+                    .padding(horizontal = 16.dp),
+        ) {
             LazyColumn {
+                // Display battery percentage at the top
+                item { DeviceCurrentStateUi(state) }
                 items(state.notifications) { notification ->
                     NotificationItem(notification = notification, onDelete = {
                         state.eventSink(AlertsListScreen.Event.DeleteNotification(notification))
@@ -181,17 +175,42 @@ fun AlertsListUi(
 }
 
 @Composable
+private fun DeviceCurrentStateUi(state: AlertsListScreen.State) {
+    Column {
+        Text(
+            text = "Battery Percentage: ${state.batteryPercentage}%",
+            modifier = Modifier.padding(2.dp),
+        )
+        // Display storage data under battery level
+        Text(
+            text = "Available Storage: ${state.availableStorage} GB",
+            modifier = Modifier.padding(2.dp),
+        )
+        Text(
+            text = "Total Storage: ${state.totalStorage} GB",
+            modifier = Modifier.padding(2.dp),
+        )
+    }
+}
+
+@Composable
 fun NotificationItem(
     notification: RemoteNotification,
     onDelete: () -> Unit,
 ) {
-    Card(modifier = Modifier.padding(8.dp).fillMaxWidth()) {
+    Card(
+        modifier =
+            Modifier
+                .padding(8.dp)
+                .fillMaxWidth(),
+    ) {
         Column(modifier = Modifier.padding(16.dp)) {
             when (notification) {
                 is RemoteNotification.BatteryNotification -> {
                     Text(text = "Battery Alert")
                     Text(text = "Battery Percentage: ${notification.batteryPercentage}%")
                 }
+
                 is RemoteNotification.StorageNotification -> {
                     Text(text = "Storage Alert")
                     Text(text = "Minimum Storage Space: ${notification.storageMinSpaceGb} GB")

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
@@ -10,13 +10,16 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
-import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
@@ -119,6 +122,7 @@ class AlertsListPresenter
         }
     }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @CircuitInject(screen = AlertsListScreen::class, scope = AppScope::class)
 @Composable
 fun AlertsListUi(
@@ -127,21 +131,30 @@ fun AlertsListUi(
 ) {
     Scaffold(
         modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Remote Alerts") },
+                actions = {
+                    IconButton(onClick = {
+                        state.eventSink(AlertsListScreen.Event.AddNotificationDestination)
+                    }) {
+                        Icon(
+                            imageVector = Icons.Default.Settings,
+                            contentDescription = "Settings",
+                        )
+                    }
+                },
+            )
+        },
         floatingActionButton = {
-            Column {
-                FloatingActionButton(onClick = { state.eventSink(AlertsListScreen.Event.AddNotification) }) {
-                    Icon(Icons.Default.Add, contentDescription = "Add Notification")
-                }
-                Spacer(modifier = Modifier.size(16.dp))
-                FloatingActionButton(onClick = {
-                    state.eventSink(AlertsListScreen.Event.AddNotificationDestination)
-                }) {
-                    Icon(Icons.Default.Notifications, contentDescription = "Add Notification Medium")
-                }
-            }
+            ExtendedFloatingActionButton(
+                onClick = { state.eventSink(AlertsListScreen.Event.AddNotification) },
+                icon = { Icon(Icons.Default.Add, contentDescription = "Add Alert Notification") },
+                text = { Text("Add Alert") },
+            )
         },
     ) { innerPadding ->
-        Column(modifier = Modifier.padding(innerPadding)) {
+        Column(modifier = Modifier.padding(innerPadding).padding(horizontal = 16.dp)) {
             // Display battery percentage at the top
             Text(
                 text = "Battery Percentage: ${state.batteryPercentage}%",


### PR DESCRIPTION
This pull request includes several enhancements and modifications to the `AlertsListScreen` in the `app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt` file. The changes focus on improving the user interface and adding new functionality related to battery and storage monitoring, as well as notification configuration.

### User Interface Enhancements:
* Added a `TopAppBar` with a settings button and updated the floating action button to use `ExtendedFloatingActionButton`. [[1]](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577R14-L25) [[2]](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577R136-R244)
* Introduced a new `NoNotifierConfiguredCard` to inform users when no notification medium is configured.

### Functional Improvements:
* Added new state properties (`batteryPercentage`, `availableStorage`, `totalStorage`, and `isAnyNotifierConfigured`) to the `AlertsListScreen.State` class.
* Updated the `AlertsListPresenter` to include `BatteryMonitor`, `StorageMonitor`, and a set of `NotificationSender` instances. [[1]](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577R80-R89) [[2]](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577L84-R117)

### Miscellaneous:
* Added `DeviceCurrentStateUi` composable to display current battery and storage states.
* Updated the `NotificationItem` composable to properly format the display of notifications.
* Modified `PreviewAlertsListUi` to include the new state properties for preview purposes.