### PR TITLE
[ADDED] Alert medium list screen based on Sonnet response

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/data/AlertMediumConfigStore.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/AlertMediumConfigStore.kt
@@ -1,0 +1,8 @@
+package dev.hossain.remotenotify.data
+
+interface AlertMediumConfigStore {
+    /**
+     * Clears all configuration for the alert medium.
+     */
+    suspend fun clearConfig()
+}

--- a/app/src/main/java/dev/hossain/remotenotify/data/TelegramConfigDataStore.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/TelegramConfigDataStore.kt
@@ -12,41 +12,49 @@ import kotlinx.coroutines.flow.map
 import timber.log.Timber
 import javax.inject.Inject
 
-private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "telegram_config")
+private val Context.telegramConfigDataStore: DataStore<Preferences> by preferencesDataStore(name = "telegram_config")
 
 class TelegramConfigDataStore
     @Inject
     constructor(
         @ApplicationContext private val context: Context,
-    ) {
+    ) : AlertMediumConfigStore {
         companion object {
             private val BOT_TOKEN_KEY = stringPreferencesKey("bot_token")
             private val CHAT_ID_KEY = stringPreferencesKey("chat_id")
         }
 
         val botToken: Flow<String?> =
-            context.dataStore.data
+            context.telegramConfigDataStore.data
                 .map { preferences ->
                     preferences[BOT_TOKEN_KEY]
                 }
 
         val chatId: Flow<String?> =
-            context.dataStore.data
+            context.telegramConfigDataStore.data
                 .map { preferences ->
                     preferences[CHAT_ID_KEY]
                 }
 
         suspend fun saveBotToken(botToken: String) {
             Timber.d("Saving bot token: $botToken")
-            context.dataStore.edit { preferences ->
+            context.telegramConfigDataStore.edit { preferences ->
                 preferences[BOT_TOKEN_KEY] = botToken
             }
         }
 
         suspend fun saveChatId(chatId: String) {
             Timber.d("Saving chat id: $chatId")
-            context.dataStore.edit { preferences ->
+            context.telegramConfigDataStore.edit { preferences ->
                 preferences[CHAT_ID_KEY] = chatId
+            }
+        }
+
+        override suspend fun clearConfig() {
+            Timber.d("Clearing Telegram configuration")
+            context.telegramConfigDataStore.edit { preferences ->
+                preferences.remove(BOT_TOKEN_KEY)
+                preferences.remove(CHAT_ID_KEY)
             }
         }
     }

--- a/app/src/main/java/dev/hossain/remotenotify/notifier/NotificationSender.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/notifier/NotificationSender.kt
@@ -17,4 +17,9 @@ interface NotificationSender {
      * Checks if all the required configuration is set for the notifier.
      */
     suspend fun hasValidConfiguration(): Boolean
+
+    /**
+     * Clears all configuration for the notifier.
+     */
+    suspend fun clearConfig()
 }

--- a/app/src/main/java/dev/hossain/remotenotify/notifier/NotifierType.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/notifier/NotifierType.kt
@@ -3,6 +3,8 @@ package dev.hossain.remotenotify.notifier
 /**
  * List of supported medium to send alert notification.
  */
-enum class NotifierType {
-    TELEGRAM,
+enum class NotifierType(
+    val displayName: String,
+) {
+    TELEGRAM("Telegram"),
 }

--- a/app/src/main/java/dev/hossain/remotenotify/notifier/TelegramNotificationSender.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/notifier/TelegramNotificationSender.kt
@@ -79,4 +79,8 @@ class TelegramNotificationSender
                 return true
             }
         }
+
+        override suspend fun clearConfig() {
+            telegramConfigDataStore.clearConfig()
+        }
     }

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
@@ -56,7 +56,7 @@ import dev.hossain.remotenotify.monitor.BatteryMonitor
 import dev.hossain.remotenotify.monitor.StorageMonitor
 import dev.hossain.remotenotify.notifier.NotificationSender
 import dev.hossain.remotenotify.ui.addalert.AddNewRemoteAlertScreen
-import dev.hossain.remotenotify.ui.addterminus.AddNotificationMediumScreen
+import dev.hossain.remotenotify.ui.alertmediumlist.NotificationMediumListScreen
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import timber.log.Timber
@@ -131,7 +131,7 @@ class AlertsListPresenter
                     }
 
                     AlertsListScreen.Event.AddNotificationDestination -> {
-                        navigator.goTo(AddNotificationMediumScreen)
+                        navigator.goTo(NotificationMediumListScreen)
                     }
                 }
             }

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/NotificationMediumListScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/NotificationMediumListScreen.kt
@@ -1,0 +1,245 @@
+package dev.hossain.remotenotify.ui.alertmediumlist
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuit.runtime.screen.Screen
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dev.hossain.remotenotify.di.AppScope
+import dev.hossain.remotenotify.notifier.NotificationSender
+import dev.hossain.remotenotify.notifier.NotifierType
+import dev.hossain.remotenotify.ui.addterminus.AddNotificationMediumScreen
+import kotlinx.coroutines.runBlocking
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data object NotificationMediumListScreen : Screen {
+    data class State(
+        val notifiers: List<NotifierInfo>,
+        val eventSink: (Event) -> Unit,
+    ) : CircuitUiState
+
+    data class NotifierInfo(
+        val id: NotifierType,
+        val name: String,
+        val isConfigured: Boolean,
+    )
+
+    sealed class Event : CircuitUiEvent {
+        data object AddNewMedium : Event()
+
+        data class EditMedium(
+            val id: NotifierType,
+        ) : Event()
+
+        data class DeleteMedium(
+            val id: NotifierType,
+        ) : Event()
+    }
+}
+
+class NotificationMediumListPresenter
+    @AssistedInject
+    constructor(
+        @Assisted private val navigator: Navigator,
+        private val notifiers: Set<@JvmSuppressWildcards NotificationSender>,
+    ) : Presenter<NotificationMediumListScreen.State> {
+        @Composable
+        override fun present(): NotificationMediumListScreen.State {
+            val notifierInfoList =
+                notifiers.map { sender ->
+                    NotificationMediumListScreen.NotifierInfo(
+                        id = sender.notifierType,
+                        name = sender.notifierType.displayName,
+                        // TODO FIX THIS LATER
+                        isConfigured = runBlocking { sender.hasValidConfiguration() },
+                    )
+                }
+
+            return NotificationMediumListScreen.State(
+                notifiers = notifierInfoList,
+            ) { event ->
+                when (event) {
+                    is NotificationMediumListScreen.Event.AddNewMedium -> {
+                        navigator.goTo(AddNotificationMediumScreen)
+                    }
+                    is NotificationMediumListScreen.Event.EditMedium -> {
+                        // Navigate to edit screen with the ID
+                        navigator.goTo(AddNotificationMediumScreen)
+                    }
+                    is NotificationMediumListScreen.Event.DeleteMedium -> {
+                        // Handle deletion through repository
+                    }
+                }
+            }
+        }
+
+        @CircuitInject(NotificationMediumListScreen::class, AppScope::class)
+        @AssistedFactory
+        fun interface Factory {
+            fun create(navigator: Navigator): NotificationMediumListPresenter
+        }
+    }
+
+@OptIn(ExperimentalMaterial3Api::class)
+@CircuitInject(NotificationMediumListScreen::class, AppScope::class)
+@Composable
+fun NotificationMediumListUi(
+    state: NotificationMediumListScreen.State,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("Notification Mediums") },
+            )
+        },
+        floatingActionButton = {
+            ExtendedFloatingActionButton(
+                onClick = { state.eventSink(NotificationMediumListScreen.Event.AddNewMedium) },
+                icon = { Icon(Icons.Default.Add, contentDescription = null) },
+                text = { Text("Add Medium") },
+            )
+        },
+    ) { padding ->
+        if (state.notifiers.isEmpty()) {
+            EmptyMediumState(
+                modifier =
+                    Modifier
+                        .padding(padding)
+                        .fillMaxWidth(),
+            )
+        } else {
+            LazyColumn(
+                modifier = Modifier.padding(padding),
+                contentPadding = PaddingValues(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(state.notifiers) { notifier ->
+                    NotifierCard(
+                        notifier = notifier,
+                        onEdit = { state.eventSink(NotificationMediumListScreen.Event.EditMedium(notifier.id)) },
+                        onDelete = { state.eventSink(NotificationMediumListScreen.Event.DeleteMedium(notifier.id)) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun NotifierCard(
+    notifier: NotificationMediumListScreen.NotifierInfo,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+    ) {
+        ListItem(
+            headlineContent = {
+                Text(notifier.name)
+            },
+            supportingContent = {
+                Text(
+                    text = if (notifier.isConfigured) "Configured" else "Not Configured",
+                    color =
+                        if (notifier.isConfigured) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.error
+                        },
+                )
+            },
+            leadingContent = {
+                Icon(
+                    imageVector = Icons.Default.Notifications,
+                    contentDescription = null,
+                    tint =
+                        if (notifier.isConfigured) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.error
+                        },
+                )
+            },
+            trailingContent = {
+                Row {
+                    IconButton(onClick = onEdit) {
+                        Icon(
+                            imageVector = Icons.Default.Settings,
+                            contentDescription = "Edit",
+                        )
+                    }
+                    IconButton(onClick = onDelete) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = "Delete",
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun EmptyMediumState(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Default.Notifications,
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+            tint = MaterialTheme.colorScheme.secondary,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            "No notification mediums configured",
+            style = MaterialTheme.typography.titleMedium,
+        )
+    }
+}

--- a/app/src/main/res/drawable/reset_settings_24dp.xml
+++ b/app/src/main/res/drawable/reset_settings_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M520,630v-60h160v60L520,630ZM580,840v-50h-60v-60h60v-50h60v160h-60ZM680,790v-60h160v60L680,790ZM720,680v-160h60v50h60v60h-60v50h-60ZM831,400h-83q-26,-88 -99,-144t-169,-56q-117,0 -198.5,81.5T200,480q0,72 32.5,132t87.5,98v-110h80v240L160,840v-80h94q-62,-50 -98,-122.5T120,480q0,-75 28.5,-140.5t77,-114q48.5,-48.5 114,-77T480,120q129,0 226.5,79.5T831,400Z"
+      android:fillColor="#e8eaed"/>
+</vector>

--- a/app/src/main/res/drawable/telegram_logo_outline.xml
+++ b/app/src/main/res/drawable/telegram_logo_outline.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <!--
+        Telegram SVG Vector
+        COLLECTION: Gentlecons Interface Icons
+        LICENSE: CC Attribution License
+        AUTHOR: Konstantin Filatov
+        https://www.svgrepo.com/svg/521874/telegram
+    -->
+
+    <path
+        android:fillColor="#0F0F0F"
+        android:fillType="evenOdd"
+        android:pathData="M23.112,4.494C23.43,2.945 21.907,1.657 20.432,2.227L2.342,9.216C0.695,9.853 0.621,12.157 2.225,12.898L6.165,14.716L8.038,21.275C8.136,21.615 8.406,21.879 8.749,21.968C9.092,22.057 9.457,21.958 9.707,21.707L12.594,18.82L16.638,21.853C17.811,22.733 19.502,22.092 19.797,20.655L23.112,4.494ZM3.063,11.082L21.153,4.093L17.837,20.253L13.1,16.7C12.702,16.401 12.145,16.441 11.793,16.793L10.557,18.029L10.928,15.986L18.207,8.707C18.561,8.353 18.599,7.791 18.295,7.393C17.991,6.995 17.439,6.883 17.004,7.132L6.951,12.876L3.063,11.082ZM8.177,14.479L8.783,16.601L9.016,15.321C9.053,15.121 9.149,14.937 9.293,14.793L11.513,12.573L8.177,14.479Z" />
+
+</vector>


### PR DESCRIPTION
Fixes #16

https://github.com/hossain-khan/android-remote-notify/issues/16#issuecomment-2659943936

----

This pull request introduces several changes to enhance the notification configuration and management system. The main changes include the addition of a new interface for clearing configuration, updates to existing classes to implement this interface, and the introduction of a new screen for managing notification mediums.

### Interface and Class Updates:
* [`app/src/main/java/dev/hossain/remotenotify/data/AlertMediumConfigStore.kt`](diffhunk://#diff-372bd27e9bbbc6d3f64b7bd0601e3aa500449fd95aac9b76280b0d056246a3e8R1-R8): Added a new interface `AlertMediumConfigStore` with a method to clear configuration.
* [`app/src/main/java/dev/hossain/remotenotify/data/TelegramConfigDataStore.kt`](diffhunk://#diff-e14ec39286872cefac09b71989cf8e0c7e4570e28de4f33925b639ffc21ad3d7L15-R59): Implemented the `AlertMediumConfigStore` interface in `TelegramConfigDataStore` and updated method names for clarity.
* [`app/src/main/java/dev/hossain/remotenotify/notifier/NotificationSender.kt`](diffhunk://#diff-293682ae0140f57d2e4eb8eb5512c785ac0731e7f715c3a98ca980c0b28e5d2aR20-R24): Added a method to clear configuration in the `NotificationSender` interface.
* [`app/src/main/java/dev/hossain/remotenotify/notifier/TelegramNotificationSender.kt`](diffhunk://#diff-9abc0b15cf281cea137367d97a633a8170b0075994048d1f7001ba55dfbd8e89R82-R85): Implemented the `clearConfig` method in `TelegramNotificationSender`.

### New Notification Medium Management Screen:
* [`app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/NotificationMediumListScreen.kt`](diffhunk://#diff-0246f0556076a11132ed5cb000a8a2652b46dc0b326c4376ff370b5c8a9f86c6R1-R261): Introduced a new screen `NotificationMediumListScreen` for managing notification mediums, with UI components and event handling for adding, editing, and deleting mediums.

### Additional Changes:
* [`app/src/main/java/dev/hossain/remotenotify/notifier/NotifierType.kt`](diffhunk://#diff-109b3486b1033f4fa3377d6c86764d7bcf838ef3ae77413dba353ffb82783c7aL6-R9): Updated the `NotifierType` enum to include a display name for each type.
* [`app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt`](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577L134-R134): Updated navigation to use the new `NotificationMediumListScreen`.
* [`app/src/main/res/drawable/reset_settings_24dp.xml`](diffhunk://#diff-895223a9a9959bb25ea6df58d8ad1a8edda2d24908ceb4d3000a25fe7a52eba9R1-R9): Added a new vector drawable for reset settings icon.
* [`app/src/main/res/drawable/telegram_logo_outline.xml`](diffhunk://#diff-b626a783835dc5ee0c066588e345b6d130f54e631901e2aef41212d5b83629e9R1-R19): Added a new vector drawable for the Telegram logo.