### PR TITLE
55 validation UI ux

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/data/AlertMediumConfigStore.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/AlertMediumConfigStore.kt
@@ -8,5 +8,5 @@ interface AlertMediumConfigStore {
 
     suspend fun hasValidConfig(): Boolean
 
-    suspend fun isValidConfig(config: AlertMediumConfig): Boolean
+    suspend fun isValidConfig(config: AlertMediumConfig): ConfigValidationResult
 }

--- a/app/src/main/java/dev/hossain/remotenotify/data/ConfigValidationResult.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/ConfigValidationResult.kt
@@ -9,6 +9,9 @@ data class ConfigValidationResult(
     val isValid: Boolean,
     /**
      * Map of error key and error message.
+     *
+     * @see WebhookConfigDataStore.ValidationKeys
+     * @see TelegramConfigDataStore.ValidationKeys
      */
     val errors: Map<String, String> = emptyMap(),
 )

--- a/app/src/main/java/dev/hossain/remotenotify/data/ConfigValidationResult.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/ConfigValidationResult.kt
@@ -1,0 +1,14 @@
+package dev.hossain.remotenotify.data
+
+data class ConfigValidationResult(
+    /**
+     * If the [AlertMediumConfig] is valid.
+     *
+     * @see AlertMediumConfigStore.isValidConfig
+     */
+    val isValid: Boolean,
+    /**
+     * Map of error key and error message.
+     */
+    val errors: Map<String, String> = emptyMap(),
+)

--- a/app/src/main/java/dev/hossain/remotenotify/data/TelegramConfigDataStore.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/TelegramConfigDataStore.kt
@@ -27,7 +27,7 @@ class TelegramConfigDataStore
             private val BOT_TOKEN_KEY = stringPreferencesKey("bot_token")
             private val CHAT_ID_KEY = stringPreferencesKey("chat_id")
 
-            private object ValidationKeys {
+            object ValidationKeys {
                 const val BOT_TOKEN = "botToken"
                 const val CHAT_ID = "chatId"
             }
@@ -92,7 +92,7 @@ class TelegramConfigDataStore
             val isValidBotToken = botToken.matches(Regex("""\d+:[A-Za-z0-9_-]{35}"""))
             if (!isValidBotToken) {
                 Timber.e("Invalid bot token format")
-                errors[ValidationKeys.BOT_TOKEN] = "Invalid bot token format"
+                errors[ValidationKeys.BOT_TOKEN] = "Invalid bot token format. Example format: 123456:ABCDEF1234ghIklzyx57W2v1u123ew11"
             }
 
             // Chat ID can be numeric or @channelusername
@@ -101,7 +101,7 @@ class TelegramConfigDataStore
                     (chatId.startsWith("@") && chatId.length > 1)
             if (!isValidChatId) {
                 Timber.e("Invalid chat ID format")
-                errors[ValidationKeys.CHAT_ID] = "Invalid chat ID format"
+                errors[ValidationKeys.CHAT_ID] = "Invalid chat ID format. Chat ID should be numeric or @channelusername"
             }
 
             Timber.i("Telegram config is valid")

--- a/app/src/main/java/dev/hossain/remotenotify/data/WebhookConfigDataStore.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/WebhookConfigDataStore.kt
@@ -26,7 +26,7 @@ class WebhookConfigDataStore
         companion object {
             private val WEBHOOK_URL_KEY = stringPreferencesKey("webhook_url")
 
-            private object ValidationKeys {
+            object ValidationKeys {
                 const val URL = "url"
             }
         }

--- a/app/src/main/java/dev/hossain/remotenotify/data/WebhookConfigDataStore.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/WebhookConfigDataStore.kt
@@ -25,6 +25,10 @@ class WebhookConfigDataStore
     ) : AlertMediumConfigStore {
         companion object {
             private val WEBHOOK_URL_KEY = stringPreferencesKey("webhook_url")
+
+            private object ValidationKeys {
+                const val URL = "url"
+            }
         }
 
         val webhookUrl: Flow<String?> =
@@ -54,14 +58,16 @@ class WebhookConfigDataStore
                 return false
             }
 
-            return isValidConfig(AlertMediumConfig.WebhookConfig(url))
+            return isValidConfig(AlertMediumConfig.WebhookConfig(url)).isValid
         }
 
-        override suspend fun isValidConfig(config: AlertMediumConfig): Boolean {
+        override suspend fun isValidConfig(config: AlertMediumConfig): ConfigValidationResult {
+            val errors = mutableMapOf<String, String>()
+
             val url =
                 when (config) {
                     is AlertMediumConfig.WebhookConfig -> config.url
-                    else -> return false
+                    else -> return ConfigValidationResult(false, emptyMap())
                 }
 
             // Basic URL validation for HTTP/HTTPS
@@ -74,12 +80,15 @@ class WebhookConfigDataStore
                 }
 
             if (!isValidUrl) {
+                errors[ValidationKeys.URL] = "Invalid URL format"
                 Timber.e("Invalid webhook URL format: $url")
-                return false
             }
 
             Timber.i("Webhook config is valid")
-            return true
+            return ConfigValidationResult(
+                isValid = errors.isEmpty(),
+                errors = errors,
+            )
         }
 
         suspend fun getConfig(): AlertMediumConfig.WebhookConfig {

--- a/app/src/main/java/dev/hossain/remotenotify/notifier/NotificationSender.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/notifier/NotificationSender.kt
@@ -40,6 +40,13 @@ interface NotificationSender {
     suspend fun isValidConfig(alertMediumConfig: AlertMediumConfig): Boolean
 }
 
+/**
+ * Extension function to find a [NotificationSender] from a set by its [NotifierType].
+ *
+ * @param senderNotifierType The type of the notifier to find.
+ * @return The [NotificationSender] matching the given [NotifierType].
+ * @throws IllegalArgumentException if no sender is found for the given [NotifierType].
+ */
 fun Set<@JvmSuppressWildcards NotificationSender>.of(senderNotifierType: NotifierType): NotificationSender =
     requireNotNull(find { it.notifierType == senderNotifierType }) {
         "Sender for notifier type not found: $senderNotifierType"

--- a/app/src/main/java/dev/hossain/remotenotify/notifier/NotificationSender.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/notifier/NotificationSender.kt
@@ -1,6 +1,7 @@
 package dev.hossain.remotenotify.notifier
 
 import dev.hossain.remotenotify.data.AlertMediumConfig
+import dev.hossain.remotenotify.data.ConfigValidationResult
 import dev.hossain.remotenotify.model.RemoteNotification
 
 /**
@@ -37,7 +38,7 @@ interface NotificationSender {
     /**
      * Validates the configuration for the notifier.
      */
-    suspend fun isValidConfig(alertMediumConfig: AlertMediumConfig): Boolean
+    suspend fun isValidConfig(alertMediumConfig: AlertMediumConfig): ConfigValidationResult
 }
 
 /**

--- a/app/src/main/java/dev/hossain/remotenotify/notifier/TelegramNotificationSender.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/notifier/TelegramNotificationSender.kt
@@ -34,7 +34,7 @@ class TelegramNotificationSender
                 }
 
             // Each bot is given a unique authentication token when it is created.
-            // The token looks something like 123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11 or 110201543:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw
+            // The token looks something like 123456:ABCDEF1234ghIklzyx57W2v1u123ew11 or 110201543:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw
             val botToken =
                 requireNotNull(telegramConfigDataStore.botToken.first()) {
                     "Bot token is required. Check `hasValidConfiguration` before using the notifier."

--- a/app/src/main/java/dev/hossain/remotenotify/notifier/TelegramNotificationSender.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/notifier/TelegramNotificationSender.kt
@@ -2,6 +2,7 @@ package dev.hossain.remotenotify.notifier
 
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dev.hossain.remotenotify.data.AlertMediumConfig
+import dev.hossain.remotenotify.data.ConfigValidationResult
 import dev.hossain.remotenotify.data.TelegramConfigDataStore
 import dev.hossain.remotenotify.di.AppScope
 import dev.hossain.remotenotify.model.RemoteNotification
@@ -92,6 +93,6 @@ class TelegramNotificationSender
             telegramConfigDataStore.clearConfig()
         }
 
-        override suspend fun isValidConfig(alertMediumConfig: AlertMediumConfig): Boolean =
+        override suspend fun isValidConfig(alertMediumConfig: AlertMediumConfig): ConfigValidationResult =
             telegramConfigDataStore.isValidConfig(alertMediumConfig)
     }

--- a/app/src/main/java/dev/hossain/remotenotify/notifier/WebhookRequestSender.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/notifier/WebhookRequestSender.kt
@@ -2,6 +2,7 @@ package dev.hossain.remotenotify.notifier
 
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dev.hossain.remotenotify.data.AlertMediumConfig
+import dev.hossain.remotenotify.data.ConfigValidationResult
 import dev.hossain.remotenotify.data.WebhookConfigDataStore
 import dev.hossain.remotenotify.di.AppScope
 import dev.hossain.remotenotify.model.RemoteNotification
@@ -89,6 +90,6 @@ class WebhookRequestSender
             webhookConfigDataStore.clearConfig()
         }
 
-        override suspend fun isValidConfig(alertMediumConfig: AlertMediumConfig): Boolean =
+        override suspend fun isValidConfig(alertMediumConfig: AlertMediumConfig): ConfigValidationResult =
             webhookConfigDataStore.isValidConfig(alertMediumConfig)
     }

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalertmedium/ConfigureNotificationMediumScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalertmedium/ConfigureNotificationMediumScreen.kt
@@ -214,10 +214,18 @@ fun ConfigureNotificationMediumUi(
 
             when (state.notifierType) {
                 NotifierType.TELEGRAM -> {
-                    TelegramConfigInputUi(state.alertMediumConfig, onConfigUpdate)
+                    TelegramConfigInputUi(
+                        alertMediumConfig = state.alertMediumConfig,
+                        configValidationResult = state.configValidationResult,
+                        onConfigUpdate = onConfigUpdate,
+                    )
                 }
                 NotifierType.WEBHOOK_REST_API -> {
-                    WebhookConfigInputUi(state.alertMediumConfig, onConfigUpdate)
+                    WebhookConfigInputUi(
+                        alertMediumConfig = state.alertMediumConfig,
+                        configValidationResult = state.configValidationResult,
+                        onConfigUpdate = onConfigUpdate,
+                    )
                 }
             }
 

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalertmedium/TelegramConfigInputUi.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalertmedium/TelegramConfigInputUi.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import dev.hossain.remotenotify.data.AlertMediumConfig
 import dev.hossain.remotenotify.data.ConfigValidationResult
+import dev.hossain.remotenotify.data.TelegramConfigDataStore.Companion.ValidationKeys
 
 @Composable
 internal fun TelegramConfigInputUi(
@@ -33,10 +34,10 @@ internal fun TelegramConfigInputUi(
             },
             label = { Text("Bot Token") },
             modifier = Modifier.fillMaxWidth(),
-            isError = shouldShowValidationError && errors["botToken"] != null,
+            isError = shouldShowValidationError && errors[ValidationKeys.BOT_TOKEN] != null,
             supportingText = {
-                if (shouldShowValidationError && errors["botToken"] != null) {
-                    Text(errors["botToken"]!!, color = MaterialTheme.colorScheme.error)
+                if (shouldShowValidationError && errors[ValidationKeys.BOT_TOKEN] != null) {
+                    Text(errors[ValidationKeys.BOT_TOKEN]!!, color = MaterialTheme.colorScheme.error)
                 } else {
                     Text("Enter bot token provided by BotFather")
                 }
@@ -52,10 +53,10 @@ internal fun TelegramConfigInputUi(
             },
             label = { Text("Chat ID") },
             modifier = Modifier.fillMaxWidth(),
-            isError = shouldShowValidationError && errors["chatId"] != null,
+            isError = shouldShowValidationError && errors[ValidationKeys.CHAT_ID] != null,
             supportingText = {
-                if (shouldShowValidationError && errors["chatId"] != null) {
-                    Text(errors["chatId"]!!, color = MaterialTheme.colorScheme.error)
+                if (shouldShowValidationError && errors[ValidationKeys.CHAT_ID] != null) {
+                    Text(errors[ValidationKeys.CHAT_ID]!!, color = MaterialTheme.colorScheme.error)
                 } else {
                     Text("Enter chat ID or @channel username")
                 }

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalertmedium/TelegramConfigInputUi.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalertmedium/TelegramConfigInputUi.kt
@@ -4,27 +4,25 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import dev.hossain.remotenotify.data.AlertMediumConfig
-import timber.log.Timber
+import dev.hossain.remotenotify.data.ConfigValidationResult
 
 @Composable
 internal fun TelegramConfigInputUi(
     alertMediumConfig: AlertMediumConfig?,
+    configValidationResult: ConfigValidationResult,
     onConfigUpdate: (AlertMediumConfig?) -> Unit,
 ) {
     val config = alertMediumConfig as AlertMediumConfig.TelegramConfig?
-
-    SideEffect {
-        Timber.d("Rendering TelegramConfigInputUi with: $config")
-    }
+    val errors = configValidationResult.errors
 
     Column {
         TextField(
@@ -34,6 +32,11 @@ internal fun TelegramConfigInputUi(
             },
             label = { Text("Bot Token") },
             modifier = Modifier.fillMaxWidth(),
+            isError = errors["botToken"] != null,
+            supportingText =
+                errors["botToken"]?.let { error ->
+                    { Text(error, color = MaterialTheme.colorScheme.error) }
+                },
         )
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -45,6 +48,11 @@ internal fun TelegramConfigInputUi(
             },
             label = { Text("Chat ID") },
             modifier = Modifier.fillMaxWidth(),
+            isError = errors["chatId"] != null,
+            supportingText =
+                errors["chatId"]?.let { error ->
+                    { Text(error, color = MaterialTheme.colorScheme.error) }
+                },
         )
     }
 }

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalertmedium/TelegramConfigInputUi.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalertmedium/TelegramConfigInputUi.kt
@@ -19,6 +19,7 @@ import dev.hossain.remotenotify.data.ConfigValidationResult
 internal fun TelegramConfigInputUi(
     alertMediumConfig: AlertMediumConfig?,
     configValidationResult: ConfigValidationResult,
+    shouldShowValidationError: Boolean,
     onConfigUpdate: (AlertMediumConfig?) -> Unit,
 ) {
     val config = alertMediumConfig as AlertMediumConfig.TelegramConfig?
@@ -32,11 +33,14 @@ internal fun TelegramConfigInputUi(
             },
             label = { Text("Bot Token") },
             modifier = Modifier.fillMaxWidth(),
-            isError = errors["botToken"] != null,
-            supportingText =
-                errors["botToken"]?.let { error ->
-                    { Text(error, color = MaterialTheme.colorScheme.error) }
-                },
+            isError = shouldShowValidationError && errors["botToken"] != null,
+            supportingText = {
+                if (shouldShowValidationError && errors["botToken"] != null) {
+                    Text(errors["botToken"]!!, color = MaterialTheme.colorScheme.error)
+                } else {
+                    Text("Enter bot token provided by BotFather")
+                }
+            },
         )
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -48,11 +52,14 @@ internal fun TelegramConfigInputUi(
             },
             label = { Text("Chat ID") },
             modifier = Modifier.fillMaxWidth(),
-            isError = errors["chatId"] != null,
-            supportingText =
-                errors["chatId"]?.let { error ->
-                    { Text(error, color = MaterialTheme.colorScheme.error) }
-                },
+            isError = shouldShowValidationError && errors["chatId"] != null,
+            supportingText = {
+                if (shouldShowValidationError && errors["chatId"] != null) {
+                    Text(errors["chatId"]!!, color = MaterialTheme.colorScheme.error)
+                } else {
+                    Text("Enter chat ID or @channel username")
+                }
+            },
         )
     }
 }

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalertmedium/WebhookConfigInputUi.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalertmedium/WebhookConfigInputUi.kt
@@ -2,25 +2,24 @@ package dev.hossain.remotenotify.ui.addalertmedium
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import dev.hossain.remotenotify.data.AlertMediumConfig
-import timber.log.Timber
+import dev.hossain.remotenotify.data.ConfigValidationResult
 
 @Composable
 internal fun WebhookConfigInputUi(
     alertMediumConfig: AlertMediumConfig?,
+    configValidationResult: ConfigValidationResult,
     onConfigUpdate: (AlertMediumConfig?) -> Unit,
 ) {
     val config = alertMediumConfig as AlertMediumConfig.WebhookConfig?
-    SideEffect {
-        Timber.d("Rendering WebhookConfigInputUi with: $alertMediumConfig")
-    }
+    val errors = configValidationResult.errors
 
     Column {
         TextField(
@@ -30,7 +29,14 @@ internal fun WebhookConfigInputUi(
             },
             label = { Text("Webhook URL") },
             modifier = Modifier.fillMaxWidth(),
-            supportingText = { Text("Enter the URL to receive notifications") },
+            isError = errors["url"] != null,
+            supportingText = {
+                if (errors["url"] != null) {
+                    Text(errors["url"]!!, color = MaterialTheme.colorScheme.error)
+                } else {
+                    Text("Enter the URL to receive notifications")
+                }
+            },
         )
     }
 }

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalertmedium/WebhookConfigInputUi.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalertmedium/WebhookConfigInputUi.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import dev.hossain.remotenotify.data.AlertMediumConfig
 import dev.hossain.remotenotify.data.ConfigValidationResult
+import dev.hossain.remotenotify.data.WebhookConfigDataStore.Companion.ValidationKeys
 
 @Composable
 internal fun WebhookConfigInputUi(
@@ -30,10 +31,10 @@ internal fun WebhookConfigInputUi(
             },
             label = { Text("Webhook URL") },
             modifier = Modifier.fillMaxWidth(),
-            isError = shouldShowValidationError && errors["url"] != null,
+            isError = shouldShowValidationError && errors[ValidationKeys.URL] != null,
             supportingText = {
-                if (shouldShowValidationError && errors["url"] != null) {
-                    Text(errors["url"]!!, color = MaterialTheme.colorScheme.error)
+                if (shouldShowValidationError && errors[ValidationKeys.URL] != null) {
+                    Text(errors[ValidationKeys.URL]!!, color = MaterialTheme.colorScheme.error)
                 } else {
                     Text("Enter the URL to receive notifications")
                 }

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalertmedium/WebhookConfigInputUi.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalertmedium/WebhookConfigInputUi.kt
@@ -16,6 +16,7 @@ import dev.hossain.remotenotify.data.ConfigValidationResult
 internal fun WebhookConfigInputUi(
     alertMediumConfig: AlertMediumConfig?,
     configValidationResult: ConfigValidationResult,
+    shouldShowValidationError: Boolean,
     onConfigUpdate: (AlertMediumConfig?) -> Unit,
 ) {
     val config = alertMediumConfig as AlertMediumConfig.WebhookConfig?
@@ -29,9 +30,9 @@ internal fun WebhookConfigInputUi(
             },
             label = { Text("Webhook URL") },
             modifier = Modifier.fillMaxWidth(),
-            isError = errors["url"] != null,
+            isError = shouldShowValidationError && errors["url"] != null,
             supportingText = {
-                if (errors["url"] != null) {
+                if (shouldShowValidationError && errors["url"] != null) {
                     Text(errors["url"]!!, color = MaterialTheme.colorScheme.error)
                 } else {
                     Text("Enter the URL to receive notifications")


### PR DESCRIPTION
Fixes #55 


https://github.com/user-attachments/assets/8012477b-88e7-47f0-86de-d0701a9ce94c

----

This pull request introduces significant changes to the configuration validation logic across multiple classes and files. The primary focus is on enhancing the validation process by replacing simple Boolean checks with a more detailed `ConfigValidationResult` data class. This change allows for more granular error reporting and better handling of invalid configurations.

### Validation Enhancements:

* [`app/src/main/java/dev/hossain/remotenotify/data/AlertMediumConfigStore.kt`](diffhunk://#diff-372bd27e9bbbc6d3f64b7bd0601e3aa500449fd95aac9b76280b0d056246a3e8L11-R11): Updated `isValidConfig` method to return `ConfigValidationResult` instead of a Boolean.
* [`app/src/main/java/dev/hossain/remotenotify/data/ConfigValidationResult.kt`](diffhunk://#diff-83ea20c0e0e32f2e24efbf9e8dbc40788b9c47c7b766313792aeb423da9f3013R1-R17): Introduced `ConfigValidationResult` data class to encapsulate validation results, including validation status and error messages.

### Telegram Configuration Updates:

* [`app/src/main/java/dev/hossain/remotenotify/data/TelegramConfigDataStore.kt`](diffhunk://#diff-e14ec39286872cefac09b71989cf8e0c7e4570e28de4f33925b639ffc21ad3d7R29-R33): Updated `isValidConfig` method to return `ConfigValidationResult` and added `ValidationKeys` for error identification. [[1]](diffhunk://#diff-e14ec39286872cefac09b71989cf8e0c7e4570e28de4f33925b639ffc21ad3d7R29-R33) [[2]](diffhunk://#diff-e14ec39286872cefac09b71989cf8e0c7e4570e28de4f33925b639ffc21ad3d7L74-R95) [[3]](diffhunk://#diff-e14ec39286872cefac09b71989cf8e0c7e4570e28de4f33925b639ffc21ad3d7L97-R111)

### Webhook Configuration Updates:

* [`app/src/main/java/dev/hossain/remotenotify/data/WebhookConfigDataStore.kt`](diffhunk://#diff-6bd527320b2a93b0074b4fd423c476a3a78860789600732b808d489a87263d9aR28-R31): Updated `isValidConfig` method to return `ConfigValidationResult` and added `ValidationKeys` for error identification. [[1]](diffhunk://#diff-6bd527320b2a93b0074b4fd423c476a3a78860789600732b808d489a87263d9aR28-R31) [[2]](diffhunk://#diff-6bd527320b2a93b0074b4fd423c476a3a78860789600732b808d489a87263d9aL57-R70) [[3]](diffhunk://#diff-6bd527320b2a93b0074b4fd423c476a3a78860789600732b808d489a87263d9aR83-R91)

### Notification Sender Updates:

* [`app/src/main/java/dev/hossain/remotenotify/notifier/NotificationSender.kt`](diffhunk://#diff-293682ae0140f57d2e4eb8eb5512c785ac0731e7f715c3a98ca980c0b28e5d2aR4): Updated `isValidConfig` method to return `ConfigValidationResult` and added an extension function to find a `NotificationSender` by its type. [[1]](diffhunk://#diff-293682ae0140f57d2e4eb8eb5512c785ac0731e7f715c3a98ca980c0b28e5d2aR4) [[2]](diffhunk://#diff-293682ae0140f57d2e4eb8eb5512c785ac0731e7f715c3a98ca980c0b28e5d2aL40-R50)
* [`app/src/main/java/dev/hossain/remotenotify/notifier/TelegramNotificationSender.kt`](diffhunk://#diff-9abc0b15cf281cea137367d97a633a8170b0075994048d1f7001ba55dfbd8e89R5): Updated `isValidConfig` method to return `ConfigValidationResult`. [[1]](diffhunk://#diff-9abc0b15cf281cea137367d97a633a8170b0075994048d1f7001ba55dfbd8e89R5) [[2]](diffhunk://#diff-9abc0b15cf281cea137367d97a633a8170b0075994048d1f7001ba55dfbd8e89L95-R96)
* [`app/src/main/java/dev/hossain/remotenotify/notifier/WebhookRequestSender.kt`](diffhunk://#diff-e247c6c95ddcf37bb5fe7847b182be4d8758da484e4e41fd9607178328c3840fR5): Updated `isValidConfig` method to return `ConfigValidationResult`. [[1]](diffhunk://#diff-e247c6c95ddcf37bb5fe7847b182be4d8758da484e4e41fd9607178328c3840fR5) [[2]](diffhunk://#diff-e247c6c95ddcf37bb5fe7847b182be4d8758da484e4e41fd9607178328c3840fL92-R93)

### UI Updates:

* [`app/src/main/java/dev/hossain/remotenotify/ui/addalertmedium/ConfigureNotificationMediumScreen.kt`](diffhunk://#diff-d8e8614e968361598ae7b794d7e829bb91de425dfd440bbf4920c8f9439e119aL60-R63): Updated UI components to handle `ConfigValidationResult` and display validation errors. (F4f19d3fL1R1, [[1]](diffhunk://#diff-d8e8614e968361598ae7b794d7e829bb91de425dfd440bbf4920c8f9439e119aL60-R63) [[2]](diffhunk://#diff-d8e8614e968361598ae7b794d7e829bb91de425dfd440bbf4920c8f9439e119aR94-R102) [[3]](diffhunk://#diff-d8e8614e968361598ae7b794d7e829bb91de425dfd440bbf4920c8f9439e119aL113-R127) [[4]](diffhunk://#diff-d8e8614e968361598ae7b794d7e829bb91de425dfd440bbf4920c8f9439e119aR165) [[5]](diffhunk://#diff-d8e8614e968361598ae7b794d7e829bb91de425dfd440bbf4920c8f9439e119aL216-R238) [[6]](diffhunk://#diff-d8e8614e968361598ae7b794d7e829bb91de425dfd440bbf4920c8f9439e119aL236-R255) [[7]](diffhunk://#diff-d8e8614e968361598ae7b794d7e829bb91de425dfd440bbf4920c8f9439e119aL260-R281)
* [`app/src/main/java/dev/hossain/remotenotify/ui/addalertmedium/TelegramConfigInputUi.kt`](diffhunk://#diff-51a6bd92e57fade995d4f4f6a3f905ad97310e4cdcca6c4fc39e45e54c9b9900R7-R27): Updated `TelegramConfigInputUi` to accept `ConfigValidationResult` and display validation errors.