### PR TITLE
[ADDED] #57 Formatter for formate alert

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/data/AlertFormatter.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/AlertFormatter.kt
@@ -1,0 +1,38 @@
+package dev.hossain.remotenotify.data
+
+import com.squareup.anvil.annotations.optional.SingleIn
+import dev.hossain.remotenotify.di.AppScope
+import dev.hossain.remotenotify.model.AlertType
+import dev.hossain.remotenotify.model.DeviceAlert
+import dev.hossain.remotenotify.model.DeviceAlert.FormatType
+import dev.hossain.remotenotify.model.RemoteAlert
+import javax.inject.Inject
+
+@SingleIn(AppScope::class)
+class AlertFormatter
+    @Inject
+    constructor() {
+        fun format(
+            remoteAlert: RemoteAlert,
+            formatType: FormatType = FormatType.TEXT,
+        ): String {
+            val deviceAlert =
+                when (remoteAlert) {
+                    is RemoteAlert.BatteryAlert ->
+                        DeviceAlert(
+                            alertType = AlertType.BATTERY,
+                            batteryLevel = remoteAlert.batteryPercentage,
+                        )
+                    is RemoteAlert.StorageAlert ->
+                        DeviceAlert(
+                            alertType = AlertType.STORAGE,
+                            availableStorageGb = remoteAlert.storageMinSpaceGb.toDouble(),
+                        )
+                }
+            return when (formatType) {
+                FormatType.JSON -> deviceAlert.toJson()
+                FormatType.TEXT -> deviceAlert.toText()
+                FormatType.EXTENDED_TEXT -> deviceAlert.toExtendedText()
+            }
+        }
+    }

--- a/app/src/main/java/dev/hossain/remotenotify/data/RemoteAlertRepository.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/RemoteAlertRepository.kt
@@ -32,8 +32,7 @@ class RemoteAlertRepositoryImpl
             alertConfigDao.insert(entity)
         }
 
-        override suspend fun getAllRemoteAlert(): List<RemoteAlert> =
-            alertConfigDao.getAll().map { it.toRemoteAlert() }
+        override suspend fun getAllRemoteAlert(): List<RemoteAlert> = alertConfigDao.getAll().map { it.toRemoteAlert() }
 
         override fun getAllRemoteAlertFlow(): Flow<List<RemoteAlert>> =
             alertConfigDao.getAllFlow().map { notificationEntities: List<AlertConfigEntity> ->

--- a/app/src/main/java/dev/hossain/remotenotify/db/AlertConfigEntity.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/db/AlertConfigEntity.kt
@@ -3,8 +3,8 @@ package dev.hossain.remotenotify.db
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import dev.hossain.remotenotify.model.BATTERY_PERCENTAGE_NONE
 import dev.hossain.remotenotify.model.AlertType
+import dev.hossain.remotenotify.model.BATTERY_PERCENTAGE_NONE
 import dev.hossain.remotenotify.model.STORAGE_MIN_SPACE_GB_NONE
 
 @Entity(tableName = "alert_config")

--- a/app/src/main/java/dev/hossain/remotenotify/di/DatabaseModule.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/di/DatabaseModule.kt
@@ -6,8 +6,8 @@ import com.squareup.anvil.annotations.ContributesTo
 import com.squareup.anvil.annotations.optional.SingleIn
 import dagger.Module
 import dagger.Provides
-import dev.hossain.remotenotify.db.AppDatabase
 import dev.hossain.remotenotify.db.AlertConfigDao
+import dev.hossain.remotenotify.db.AppDatabase
 
 @Module
 @ContributesTo(AppScope::class)

--- a/app/src/main/java/dev/hossain/remotenotify/model/DeviceAlert.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/model/DeviceAlert.kt
@@ -9,22 +9,22 @@ data class DeviceAlert(
     val androidVersion: String = android.os.Build.VERSION.RELEASE,
     val batteryLevel: Int? = null,
     val availableStorageGb: Double? = null,
-    val timestamp: LocalDateTime = LocalDateTime.now()
+    val timestamp: LocalDateTime = LocalDateTime.now(),
 ) {
-
-    fun format(formatType: FormatType): String {
-        return when (formatType) {
+    fun format(formatType: FormatType): String =
+        when (formatType) {
             FormatType.JSON -> toJson()
             FormatType.TEXT -> toText()
             FormatType.EXTENDED_TEXT -> toExtendedText()
         }
-    }
 
     enum class FormatType {
-        JSON, TEXT, EXTENDED_TEXT
+        JSON,
+        TEXT,
+        EXTENDED_TEXT,
     }
 
-    private fun toJson(): String {
+    internal fun toJson(): String {
         val batteryLevelJson = batteryLevel?.let { ",\"batteryLevel\":$it" } ?: ""
         val storageGbJson = availableStorageGb?.let { ",\"availableStorageGb\":$it" } ?: ""
         val formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
@@ -37,36 +37,39 @@ data class DeviceAlert(
                 "androidVersion": "$androidVersion",
                 "timestamp": "$formattedTimestamp"$batteryLevelJson$storageGbJson
             }
-        """.trimIndent()
+            """.trimIndent()
     }
 
-    private fun toText(): String {
+    internal fun toText(): String {
         val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
         val formattedTimestamp = timestamp.format(formatter)
-        val alertMessage = when (alertType) {
-            AlertType.BATTERY -> "Battery Level: $batteryLevel%"
-            AlertType.STORAGE -> "Available Storage: $availableStorageGb GB"
-        }
+        val alertMessage =
+            when (alertType) {
+                AlertType.BATTERY -> "Battery Level: $batteryLevel%"
+                AlertType.STORAGE -> "Available Storage: $availableStorageGb GB"
+            }
 
         return """
             ${alertType.name} Alert!
             Device: $deviceModel ($androidVersion)
             $alertMessage
             Time: $formattedTimestamp
-        """.trimIndent()
+            """.trimIndent()
     }
 
-    private fun toExtendedText(): String {
+    internal fun toExtendedText(): String {
         val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
         val formattedTimestamp = timestamp.format(formatter)
-        val alertMessage = when (alertType) {
-            AlertType.BATTERY -> "Battery Level: $batteryLevel%\nAction: Please check charging status."
-            AlertType.STORAGE -> "Available Storage: $availableStorageGb GB\nAction: Consider clearing storage space."
-        }
-        val emoji = when (alertType) {
-            AlertType.BATTERY -> "🪫"
-            AlertType.STORAGE -> "💾"
-        }
+        val alertMessage =
+            when (alertType) {
+                AlertType.BATTERY -> "Battery Level: $batteryLevel%\nAction: Please check charging status."
+                AlertType.STORAGE -> "Available Storage: $availableStorageGb GB\nAction: Consider clearing storage space."
+            }
+        val emoji =
+            when (alertType) {
+                AlertType.BATTERY -> "🪫"
+                AlertType.STORAGE -> "💾"
+            }
 
         return """
             $emoji ${alertType.name} Alert! $emoji
@@ -74,25 +77,27 @@ data class DeviceAlert(
             Device: $deviceModel ($androidVersion)
             $alertMessage
             Time: $formattedTimestamp
-        """.trimIndent()
+            """.trimIndent()
     }
 }
 
 // Example usage:
 fun main() {
-    val batteryAlert = DeviceAlert(
-        alertType = AlertType.BATTERY,
-        deviceModel = "Pixel 7",
-        androidVersion = "Android 14",
-        batteryLevel = 15
-    )
+    val batteryAlert =
+        DeviceAlert(
+            alertType = AlertType.BATTERY,
+            deviceModel = "Pixel 7",
+            androidVersion = "Android 14",
+            batteryLevel = 15,
+        )
 
-    val storageAlert = DeviceAlert(
-        alertType = AlertType.STORAGE,
-        deviceModel = "Samsung Galaxy S23",
-        androidVersion = "Android 13",
-        availableStorageGb = 3.2
-    )
+    val storageAlert =
+        DeviceAlert(
+            alertType = AlertType.STORAGE,
+            deviceModel = "Samsung Galaxy S23",
+            androidVersion = "Android 13",
+            availableStorageGb = 3.2,
+        )
 
     println("Battery Alert (JSON):")
     println(batteryAlert.format(DeviceAlert.FormatType.JSON))

--- a/app/src/main/java/dev/hossain/remotenotify/notifier/TelegramNotificationSender.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/notifier/TelegramNotificationSender.kt
@@ -1,6 +1,7 @@
 package dev.hossain.remotenotify.notifier
 
 import com.squareup.anvil.annotations.ContributesMultibinding
+import dev.hossain.remotenotify.data.AlertFormatter
 import dev.hossain.remotenotify.data.ConfigValidationResult
 import dev.hossain.remotenotify.data.TelegramConfigDataStore
 import dev.hossain.remotenotify.di.AppScope
@@ -22,16 +23,13 @@ class TelegramNotificationSender
     constructor(
         private val telegramConfigDataStore: TelegramConfigDataStore,
         private val okHttpClient: OkHttpClient,
+        private val alertFormatter: AlertFormatter,
     ) : NotificationSender {
         override val notifierType: NotifierType = NotifierType.TELEGRAM
 
         override suspend fun sendNotification(remoteAlert: RemoteAlert): Boolean {
             // Text of the message to be sent, 1-4096 characters after entities parsing
-            val message =
-                when (remoteAlert) {
-                    is RemoteAlert.BatteryAlert -> "Battery Alert: ${remoteAlert.batteryPercentage}%"
-                    is RemoteAlert.StorageAlert -> "Storage Alert: ${remoteAlert.storageMinSpaceGb}GB available"
-                }
+            val message = alertFormatter.format(remoteAlert)
 
             // Each bot is given a unique authentication token when it is created.
             // The token looks something like 123456:ABCDEF1234ghIklzyx57W2v1u123ew11 or 110201543:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw


### PR DESCRIPTION
* https://github.com/hossain-khan/android-remote-notify/issues/57

This is extension of:
* https://github.com/hossain-khan/android-remote-notify/pull/59


----


This pull request introduces a new `AlertFormatter` class to centralize the formatting logic for alerts and integrates this formatter across various parts of the codebase. Additionally, it includes minor code cleanups and refactors for better readability and maintainability.

### Introduction of `AlertFormatter`:

* [`app/src/main/java/dev/hossain/remotenotify/data/AlertFormatter.kt`](diffhunk://#diff-f04d5cbb0dade6f6b3445bcc7916d6ff3f752901eb2a4b3ac5b3bcd454cae035R1-R38): Added a new `AlertFormatter` class to handle the formatting of `RemoteAlert` objects into different string formats. (`[app/src/main/java/dev/hossain/remotenotify/data/AlertFormatter.ktR1-R38](diffhunk://#diff-f04d5cbb0dade6f6b3445bcc7916d6ff3f752901eb2a4b3ac5b3bcd454cae035R1-R38)`)

### Integration of `AlertFormatter`:

* [`app/src/main/java/dev/hossain/remotenotify/notifier/TelegramNotificationSender.kt`](diffhunk://#diff-9abc0b15cf281cea137367d97a633a8170b0075994048d1f7001ba55dfbd8e89R4): Modified the `TelegramNotificationSender` class to use `AlertFormatter` for formatting the alert messages. (`[[1]](diffhunk://#diff-9abc0b15cf281cea137367d97a633a8170b0075994048d1f7001ba55dfbd8e89R4)`, `[[2]](diffhunk://#diff-9abc0b15cf281cea137367d97a633a8170b0075994048d1f7001ba55dfbd8e89R26-R32)`)
* [`app/src/main/java/dev/hossain/remotenotify/notifier/WebhookRequestSender.kt`](diffhunk://#diff-e247c6c95ddcf37bb5fe7847b182be4d8758da484e4e41fd9607178328c3840fR4-L16): Modified the `WebhookRequestSender` class to use `AlertFormatter` for formatting the alert payload in JSON format. Removed the `buildJsonPayload` method as it is now redundant. (`[[1]](diffhunk://#diff-e247c6c95ddcf37bb5fe7847b182be4d8758da484e4e41fd9607178328c3840fR4-L16)`, `[[2]](diffhunk://#diff-e247c6c95ddcf37bb5fe7847b182be4d8758da484e4e41fd9607178328c3840fL27-R27)`, `[[3]](diffhunk://#diff-e247c6c95ddcf37bb5fe7847b182be4d8758da484e4e41fd9607178328c3840fL37-R37)`, `[[4]](diffhunk://#diff-e247c6c95ddcf37bb5fe7847b182be4d8758da484e4e41fd9607178328c3840fL56-L77)`)

### Code Cleanups and Refactors:

* [`app/src/main/java/dev/hossain/remotenotify/model/DeviceAlert.kt`](diffhunk://#diff-f820c134deac21109d0fe981113228e42fb8bc7518f4244c1431194c1c61ebfaL12-R27): Changed the visibility of the `toJson`, `toText`, and `toExtendedText` methods to `internal` and reformatted the code for better readability. (`[[1]](diffhunk://#diff-f820c134deac21109d0fe981113228e42fb8bc7518f4244c1431194c1c61ebfaL12-R27)`, `[[2]](diffhunk://#diff-f820c134deac21109d0fe981113228e42fb8bc7518f4244c1431194c1c61ebfaL43-R47)`, `[[3]](diffhunk://#diff-f820c134deac21109d0fe981113228e42fb8bc7518f4244c1431194c1c61ebfaL59-R69)`, `[[4]](diffhunk://#diff-f820c134deac21109d0fe981113228e42fb8bc7518f4244c1431194c1c61ebfaL83-R99)`)
* [`app/src/main/java/dev/hossain/remotenotify/data/RemoteAlertRepository.kt`](diffhunk://#diff-4c1e5e4fe3aeaf1ac7db3accd5a2b19b5ac406a4b9c9b212d1aeb9fd1781be27L35-R35): Simplified the `getAllRemoteAlert` method by removing unnecessary line breaks. (`[app/src/main/java/dev/hossain/remotenotify/data/RemoteAlertRepository.ktL35-R35](diffhunk://#diff-4c1e5e4fe3aeaf1ac7db3accd5a2b19b5ac406a4b9c9b212d1aeb9fd1781be27L35-R35)`)
* [`app/src/main/java/dev/hossain/remotenotify/db/AlertConfigEntity.kt`](diffhunk://#diff-efa8c9d5b8049e6fcf27f58161512f92ada23525e7e50af98e4d9017f6d88a08L6-R7): Reorganized imports for better readability. (`[app/src/main/java/dev/hossain/remotenotify/db/AlertConfigEntity.ktL6-R7](diffhunk://#diff-efa8c9d5b8049e6fcf27f58161512f92ada23525e7e50af98e4d9017f6d88a08L6-R7)`)
* [`app/src/main/java/dev/hossain/remotenotify/di/DatabaseModule.kt`](diffhunk://#diff-3293c53d25e52d1e56c0217cd71b3ca6d3c01bee062fa12ebab0b9f8916e918cL9-R10): Reorganized imports for better readability. (`[app/src/main/java/dev/hossain/remotenotify/di/DatabaseModule.ktL9-R10](diffhunk://#diff-3293c53d25e52d1e56c0217cd71b3ca6d3c01bee062fa12ebab0b9f8916e918cL9-R10)`)