### PR TITLE
[ADDED] Wonderful Light, Dark and Color scheme UI previews

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/ui/about/AboutAppScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/about/AboutAppScreen.kt
@@ -35,7 +35,8 @@ import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewDynamicColors
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.CircuitUiEvent
@@ -230,9 +231,9 @@ private fun AppTagLineWithLinkedText(
     )
 }
 
-@Preview(showBackground = true, name = "Light Mode")
-@Preview(showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES, name = "Dark Mode")
 @Composable
+@PreviewLightDark
+@PreviewDynamicColors
 fun AboutAppScreenPreview() {
     val sampleState =
         AboutAppScreen.State(

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlert.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlert.kt
@@ -32,7 +32,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewDynamicColors
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.CircuitUiEvent
@@ -49,6 +50,7 @@ import dev.hossain.remotenotify.di.AppScope
 import dev.hossain.remotenotify.model.AlertType
 import dev.hossain.remotenotify.model.RemoteAlert
 import dev.hossain.remotenotify.model.toIconResId
+import dev.hossain.remotenotify.theme.ComposeAppTheme
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 
@@ -297,13 +299,16 @@ private fun AlertTypeSelector(
     }
 }
 
-@Preview(showBackground = true)
 @Composable
+@PreviewLightDark
+@PreviewDynamicColors
 fun PreviewAddNewRemoteAlertUi() {
-    AddNewRemoteAlertUi(
-        state =
-            AddNewRemoteAlertScreen.State(
-                eventSink = {},
-            ),
-    )
+    ComposeAppTheme {
+        AddNewRemoteAlertUi(
+            state =
+                AddNewRemoteAlertScreen.State(
+                    eventSink = {},
+                ),
+        )
+    }
 }

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/FirstTimeUserEducationSheetUi.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/FirstTimeUserEducationSheetUi.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -30,7 +31,8 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewDynamicColors
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import dev.hossain.remotenotify.theme.ComposeAppTheme
 
@@ -125,12 +127,15 @@ private fun EducationContentUi(eventSink: (AlertsListScreen.Event) -> Unit) {
     }
 }
 
-@Preview(showBackground = true)
 @Composable
+@PreviewLightDark
+@PreviewDynamicColors
 fun PreviewFirstTimeUserEducationSheetUi() {
     ComposeAppTheme {
-        EducationContentUi(
-            eventSink = { /* Preview event sink */ },
-        )
+        Surface {
+            EducationContentUi(
+                eventSink = { /* Preview event sink */ },
+            )
+        }
     }
 }

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/NoNotifierConfiguredCardUi.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/NoNotifierConfiguredCardUi.kt
@@ -13,11 +13,13 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewDynamicColors
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import dev.hossain.remotenotify.theme.ComposeAppTheme
 
@@ -59,12 +61,15 @@ internal fun NoNotifierConfiguredCard(
     }
 }
 
-@Preview(showBackground = true)
 @Composable
+@PreviewLightDark
+@PreviewDynamicColors
 private fun PreviewNoNotifierConfiguredCard() {
     ComposeAppTheme {
-        NoNotifierConfiguredCard(
-            onConfigureClick = {},
-        )
+        Surface {
+            NoNotifierConfiguredCard(
+                onConfigureClick = {},
+            )
+        }
     }
 }

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumconfig/ConfigureNotificationMediumScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumconfig/ConfigureNotificationMediumScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewDynamicColors
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.CircuitUiEvent
@@ -54,6 +56,7 @@ import dev.hossain.remotenotify.model.RemoteAlert
 import dev.hossain.remotenotify.notifier.NotificationSender
 import dev.hossain.remotenotify.notifier.NotifierType
 import dev.hossain.remotenotify.notifier.of
+import dev.hossain.remotenotify.theme.ComposeAppTheme
 import dev.hossain.remotenotify.ui.alertmediumconfig.ConfigureNotificationMediumScreen.ConfigurationResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -361,10 +364,11 @@ private fun PreviewTelegramConfigurationUi() {
     }
 }
 
-@Preview
 @Composable
+@PreviewLightDark
+@PreviewDynamicColors
 private fun PreviewWebhookConfigurationUi() {
-    MaterialTheme {
+    ComposeAppTheme {
         ConfigureNotificationMediumUi(
             state =
                 ConfigureNotificationMediumScreen.State(

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/NotificationMediumListScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/NotificationMediumListScreen.kt
@@ -47,6 +47,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewDynamicColors
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.foundation.rememberAnsweringNavigator
@@ -63,6 +65,7 @@ import dev.hossain.remotenotify.data.AppPreferencesDataStore
 import dev.hossain.remotenotify.di.AppScope
 import dev.hossain.remotenotify.notifier.NotificationSender
 import dev.hossain.remotenotify.notifier.NotifierType
+import dev.hossain.remotenotify.theme.ComposeAppTheme
 import dev.hossain.remotenotify.ui.alertmediumconfig.ConfigureNotificationMediumScreen
 import dev.hossain.remotenotify.worker.DEFAULT_PERIODIC_INTERVAL_MINUTES
 import dev.hossain.remotenotify.worker.sendPeriodicWorkRequest
@@ -478,3 +481,41 @@ private fun NotifierType.iconResId(): Int =
         NotifierType.TWILIO -> R.drawable.twilio_logo_outline
         NotifierType.WEBHOOK_REST_API -> R.drawable.webhook_24dp
     }
+
+@Composable
+@PreviewLightDark
+@PreviewDynamicColors
+private fun PreviewNotificationMediumListUi() {
+    ComposeAppTheme {
+        NotificationMediumListUi(
+            state =
+                NotificationMediumListScreen.State(
+                    workerIntervalMinutes = 60,
+                    notifiers =
+                        listOf(
+                            NotificationMediumListScreen.NotifierMediumInfo(
+                                notifierType = NotifierType.EMAIL,
+                                name = "Email",
+                                isConfigured = true,
+                            ),
+                            NotificationMediumListScreen.NotifierMediumInfo(
+                                notifierType = NotifierType.TELEGRAM,
+                                name = "Telegram",
+                                isConfigured = false,
+                            ),
+                            NotificationMediumListScreen.NotifierMediumInfo(
+                                notifierType = NotifierType.TWILIO,
+                                name = "Twilio SMS",
+                                isConfigured = true,
+                            ),
+                            NotificationMediumListScreen.NotifierMediumInfo(
+                                notifierType = NotifierType.WEBHOOK_REST_API,
+                                name = "Webhook",
+                                isConfigured = false,
+                            ),
+                        ),
+                    eventSink = {},
+                ),
+        )
+    }
+}

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/PlaystoreFeedbackSection.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/PlaystoreFeedbackSection.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
@@ -16,7 +17,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewDynamicColors
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import dev.hossain.remotenotify.theme.ComposeAppTheme
 import dev.hossain.remotenotify.utils.InAppReviewManager
@@ -64,10 +66,13 @@ fun FeedbackAndRequestMediumUi() {
     }
 }
 
-@Preview(showBackground = true)
 @Composable
+@PreviewLightDark
+@PreviewDynamicColors
 fun PreviewRatingSection() {
     ComposeAppTheme {
-        FeedbackAndRequestMediumUi()
+        Surface {
+            FeedbackAndRequestMediumUi()
+        }
     }
 }


### PR DESCRIPTION
<img width="585" alt="Screenshot 2025-02-19 at 5 48 24 PM" src="https://github.com/user-attachments/assets/9f057323-b096-448b-b9bb-f165c4cdb106" />


This pull request includes updates to the preview annotations and themes used in multiple UI components across the project. The changes mainly involve replacing individual `@Preview` annotations with new custom annotations and ensuring consistent usage of the `ComposeAppTheme`.

Preview annotations and themes updates:

* [`app/src/main/java/dev/hossain/remotenotify/ui/about/AboutAppScreen.kt`](diffhunk://#diff-46d22ad5abd2b65700fdc3f9c918ff9853e3979954f44fdbde2415a15f1cabecL38-R39): Replaced individual `@Preview` annotations with `@PreviewLightDark` and `@PreviewDynamicColors` for `AboutAppScreenPreview` and updated imports accordingly. [[1]](diffhunk://#diff-46d22ad5abd2b65700fdc3f9c918ff9853e3979954f44fdbde2415a15f1cabecL38-R39) [[2]](diffhunk://#diff-46d22ad5abd2b65700fdc3f9c918ff9853e3979954f44fdbde2415a15f1cabecL233-R236)
* [`app/src/main/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlert.kt`](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fL35-R36): Replaced individual `@Preview` annotations with `@PreviewLightDark` and `@PreviewDynamicColors` for `PreviewAddNewRemoteAlertUi`, and added `ComposeAppTheme` wrapping. [[1]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fL35-R36) [[2]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR53) [[3]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fL300-R314)
* [`app/src/main/java/dev/hossain/remotenotify/ui/alertlist/FirstTimeUserEducationSheetUi.kt`](diffhunk://#diff-54c6e0cadffb507851b98451e1c2765cb123b27703ace856a570099585a65e12R23): Replaced individual `@Preview` annotations with `@PreviewLightDark` and `@PreviewDynamicColors` for `PreviewFirstTimeUserEducationSheetUi`, and added `Surface` wrapping. [[1]](diffhunk://#diff-54c6e0cadffb507851b98451e1c2765cb123b27703ace856a570099585a65e12R23) [[2]](diffhunk://#diff-54c6e0cadffb507851b98451e1c2765cb123b27703ace856a570099585a65e12L33-R35) [[3]](diffhunk://#diff-54c6e0cadffb507851b98451e1c2765cb123b27703ace856a570099585a65e12L128-R141)
* [`app/src/main/java/dev/hossain/remotenotify/ui/alertlist/NoNotifierConfiguredCardUi.kt`](diffhunk://#diff-83d72daa92fd90f79ffc0b96e660eb51f7c2b41630db52c3f3dc3218a2c5abcaR16-R22): Replaced individual `@Preview` annotations with `@PreviewLightDark` and `@PreviewDynamicColors` for `PreviewNoNotifierConfiguredCard`, and added `Surface` wrapping. [[1]](diffhunk://#diff-83d72daa92fd90f79ffc0b96e660eb51f7c2b41630db52c3f3dc3218a2c5abcaR16-R22) [[2]](diffhunk://#diff-83d72daa92fd90f79ffc0b96e660eb51f7c2b41630db52c3f3dc3218a2c5abcaL62-R75)
* [`app/src/main/java/dev/hossain/remotenotify/ui/alertmediumconfig/ConfigureNotificationMediumScreen.kt`](diffhunk://#diff-7a0a437dd9de4ce5cba2c34a3e1cac55594ece6ac1b485c6a26237d8e598943cR37-R38): Replaced individual `@Preview` annotations with `@PreviewLightDark` and `@PreviewDynamicColors` for `PreviewWebhookConfigurationUi`, and added `ComposeAppTheme` wrapping. [[1]](diffhunk://#diff-7a0a437dd9de4ce5cba2c34a3e1cac55594ece6ac1b485c6a26237d8e598943cR37-R38) [[2]](diffhunk://#diff-7a0a437dd9de4ce5cba2c34a3e1cac55594ece6ac1b485c6a26237d8e598943cR59) [[3]](diffhunk://#diff-7a0a437dd9de4ce5cba2c34a3e1cac55594ece6ac1b485c6a26237d8e598943cL364-R371)
* [`app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/NotificationMediumListScreen.kt`](diffhunk://#diff-0246f0556076a11132ed5cb000a8a2652b46dc0b326c4376ff370b5c8a9f86c6R50-R51): Added `@PreviewLightDark` and `@PreviewDynamicColors` annotations for `PreviewNotificationMediumListUi`, and added `ComposeAppTheme` wrapping. [[1]](diffhunk://#diff-0246f0556076a11132ed5cb000a8a2652b46dc0b326c4376ff370b5c8a9f86c6R50-R51) [[2]](diffhunk://#diff-0246f0556076a11132ed5cb000a8a2652b46dc0b326c4376ff370b5c8a9f86c6R68) [[3]](diffhunk://#diff-0246f0556076a11132ed5cb000a8a2652b46dc0b326c4376ff370b5c8a9f86c6R484-R521)
* [`app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/PlaystoreFeedbackSection.kt`](diffhunk://#diff-9c0ef9635c609b0bcc19c875176927a8bb6a9105862700e537ed8e13e8714acbR12-R21): Replaced individual `@Preview` annotations with `@PreviewLightDark` and `@PreviewDynamicColors` for `PreviewRatingSection`, and added `Surface` wrapping. [[1]](diffhunk://#diff-9c0ef9635c609b0bcc19c875176927a8bb6a9105862700e537ed8e13e8714acbR12-R21) [[2]](diffhunk://#diff-9c0ef9635c609b0bcc19c875176927a8bb6a9105862700e537ed8e13e8714acbL67-R78)