### PR TITLE
[UPDATE] Enabled Proguard R8 minification

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,7 +44,8 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,56 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+
+# Keep Kotlin Serialization
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.AnnotationsKt
+-keepclassmembers class kotlinx.serialization.json.** { *; }
+
+# Circuit
+-keep class * extends com.slack.circuit.foundation.Circuit { *; }
+-keep @com.slack.circuit.codegen.annotations.CircuitInject class * { *; }
+
+# Dagger
+-keepclassmembers,allowobfuscation class * {
+    @javax.inject.* *;
+    @dagger.* *;
+}
+
+# Room
+-keep class * extends androidx.room.RoomDatabase
+-keep @androidx.room.Entity class *
+-keep @androidx.room.Dao class *
+
+# Retrofit/OkHttp
+-keepattributes Signature
+-keepattributes *Annotation*
+-keep class retrofit2.** { *; }
+-keepclassmembers,allowshrinking,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+-dontwarn okhttp3.**
+-dontwarn okio.**
+
+# Moshi
+-keep class * extends com.squareup.moshi.JsonAdapter
+-keep class dev.hossain.remotenotify.** { *; }
+-keepclassmembers class dev.hossain.remotenotify.** { *; }
+
+# Firebase Crashlytics
+-keep class com.google.firebase.crashlytics.** { *; }
+
+# WorkManager
+-keepclassmembers class * extends androidx.work.Worker {
+    public <init>(android.content.Context,androidx.work.WorkerParameters);
+}
+
+# Keep source file names and line numbers for better crash reports
+-keepattributes SourceFile,LineNumberTable
+
+# Keep enums
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}


### PR DESCRIPTION
Fixes #115


```
OLD: app-release.apk (signature: V2)
NEW: app-release.apk (signature: V2)

          │             compressed             │            uncompressed            
          ├───────────┬───────────┬────────────┼───────────┬───────────┬────────────
 APK      │ old       │ new       │ diff       │ old       │ new       │ diff       
──────────┼───────────┼───────────┼────────────┼───────────┼───────────┼────────────
      dex │    31 MiB │   5.5 MiB │  -25.5 MiB │    31 MiB │   5.5 MiB │  -25.5 MiB 
     arsc │ 548.7 KiB │ 302.2 KiB │ -246.4 KiB │ 548.6 KiB │ 302.1 KiB │ -246.4 KiB 
 manifest │   4.2 KiB │   4.2 KiB │       -1 B │  20.6 KiB │  20.6 KiB │        0 B 
      res │ 134.9 KiB │ 125.1 KiB │   -9.8 KiB │ 182.3 KiB │ 159.6 KiB │  -22.6 KiB 
   native │ 190.7 KiB │ 200.7 KiB │    +10 KiB │  58.9 KiB │  58.9 KiB │        0 B 
    asset │   9.1 KiB │   6.1 KiB │     -3 KiB │   8.8 KiB │   5.8 KiB │     -3 KiB 
    other │  85.5 KiB │    86 KiB │     +562 B │ 101.5 KiB │ 102.4 KiB │     +963 B 
──────────┼───────────┼───────────┼────────────┼───────────┼───────────┼────────────
    total │  31.9 MiB │   6.2 MiB │  -25.7 MiB │  31.9 MiB │   6.1 MiB │  -25.7 MiB 

         │           raw            │                  unique                   
         ├────────┬───────┬─────────┼────────┬───────┬──────────────────────────
 DEX     │ old    │ new   │ diff    │ old    │ new   │ diff                     
─────────┼────────┼───────┼─────────┼────────┼───────┼──────────────────────────
   files │      3 │     1 │      -2 │        │       │                          
 strings │ 179440 │ 29880 │ -149560 │ 165498 │ 29880 │ -135618 (+6993 -142611)  
   types │  30529 │  8124 │  -22405 │  28556 │  8124 │  -20432 (+6082 -26514)   
 classes │  26309 │  6929 │  -19380 │  26309 │  6929 │  -19380 (+5793 -25173)   
 methods │ 188354 │ 36924 │ -151430 │ 183895 │ 36924 │ -146971 (+29313 -176284) 
  fields │  68588 │ 21094 │  -47494 │  68046 │ 21094 │  -46952 (+18722 -65674)  

 ARSC    │ old │ new │ diff         
─────────┼─────┼─────┼──────────────
 configs │ 109 │ 109 │   0          
 entries │ 435 │ 357 │ -78 (+0 -78) 

=================
====   APK   ====
=================

       compressed       │      uncompressed      │                                                                                              
───────────┬────────────┼───────────┬────────────┤                                                                                              
 size      │ diff       │ size      │ diff       │ path                                                                                         
───────────┼────────────┼───────────┼────────────┼──────────────────────────────────────────────────────────────────────────────────────────────
           │   -9.4 MiB │           │   -9.4 MiB │ - classes3.dex                                                                               
   5.5 MiB │   -8.1 MiB │   5.5 MiB │   -8.1 MiB │ ∆ classes.dex                                                                                
           │     -8 MiB │           │     -8 MiB │ - classes2.dex                                                                               
 302.2 KiB │ -246.4 KiB │ 302.1 KiB │ -246.4 KiB │ ∆ resources.arsc                                                                             
  33.2 KiB │    +10 KiB │   9.9 KiB │        0 B │ ∆ lib/arm64-v8a/libandroidx.graphics.path.so                                                 
   5.3 KiB │   -3.1 KiB │   5.1 KiB │   -3.1 KiB │ ∆ assets/dexopt/baseline.prof                                                                
           │   -2.2 KiB │           │   -5.3 KiB │ - res/Ls.xml                                                                                 
           │   -1.5 KiB │           │   -3.1 KiB │ - res/VV.xml                                                                                 
           │   -1.1 KiB │           │   -5.6 KiB │ - res/Dk.xml                                                                                 
           │     -830 B │           │   -1.5 KiB │ - res/x4.xml                                                                                 
           │     -808 B │           │   -1.5 KiB │ - res/Xk.xml                                                                                 
           │     -759 B │           │   -1.3 KiB │ - res/bX.xml                                                                                 
           │     -740 B │           │   -1.3 KiB │ - res/Ce.xml                                                                                 
     623 B │     +623 B │   1.1 KiB │   +1.1 KiB │ + META-INF/app_release.kotlin_module                                                         
           │     -578 B │           │     -1 KiB │ - res/DW.xml                                                                                 
           │     -517 B │           │     -772 B │ - res/WU.xml                                                                                 
           │     -497 B │           │     -736 B │ - res/N3.xml                                                                                 
           │     -405 B │           │     -612 B │ - res/_y.xml                                                                                 
           │     -355 B │           │     -235 B │ - META-INF/services/kotlin.reflect.jvm.internal.impl.resolve.ExternalOverridabilityCondition 
           │     -296 B │           │      -90 B │ - META-INF/services/kotlin.reflect.jvm.internal.impl.builtins.BuiltInsLoader                 
     274 B │     +274 B │     140 B │     +140 B │ + META-INF/com.google.firebase-firebase-crashlytics.kotlin_module                            
           │     -259 B │           │      -52 B │ - META-INF/services/kotlinx.coroutines.internal.MainDispatcherFactory                        
           │     -250 B │           │      -54 B │ - META-INF/services/kotlinx.coroutines.CoroutineExceptionHandler                             
     212 B │     +212 B │      88 B │      +88 B │ + META-INF/ui_release.kotlin_module                                                          
     184 B │     +184 B │      51 B │      +51 B │ + META-INF/retrofit.kotlin_module                                                            
     843 B │     +151 B │     707 B │     +149 B │ ∆ assets/dexopt/baseline.profm                                                               
     134 B │     +134 B │      15 B │      +15 B │ + META-INF/services/M4.e                                                                     
     127 B │     +127 B │       5 B │       +5 B │ + META-INF/services/i4.c                                                                     
     127 B │     +127 B │       5 B │       +5 B │ + META-INF/services/u5.t                                                                     
     127 B │     +127 B │       5 B │       +5 B │ + META-INF/services/v5.a                                                                     
  40.6 KiB │      +11 B │  40.4 KiB │        0 B │ ∆ okhttp3/internal/publicsuffix/publicsuffixes.gz                                            
     777 B │       -6 B │     681 B │        0 B │ ∆ res/ZI.png                                                                                 
     187 B │       -4 B │       7 B │        0 B │ ∆ META-INF/androidx.activity_activity-compose.version                                        
     204 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.annotation_annotation-experimental.version                               
     190 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.animation_animation.version                                      
     213 B │       -4 B │      13 B │        0 B │ ∆ META-INF/androidx.compose.material3.adaptive_adaptive.version                              
     182 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.runtime_runtime.version                                          
     198 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.ui_ui-text-google-fonts.version                                  
     212 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.customview_customview-poolingcontainer.version                           
     198 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.datastore_datastore-preferences.version                                  
     174 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.datastore_datastore.version                                              
     190 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.lifecycle_lifecycle-process.version                                      
     206 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.lifecycle_lifecycle-runtime-compose.version                              
     198 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.lifecycle_lifecycle-runtime-ktx.version                                  
     190 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.lifecycle_lifecycle-runtime.version                                      
     190 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.lifecycle_lifecycle-service.version                                      
     222 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.localbroadcastmanager_localbroadcastmanager.version                      
     158 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.print_print.version                                                      
     182 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.sqlite_sqlite-framework.version                                          
     182 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.startup_startup-runtime.version                                          
     174 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.tracing_tracing-ktx.version                                              
     166 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.tracing_tracing.version                                                  
     214 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.versionedparcelable_versionedparcelable.version                          
     174 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.viewpager_viewpager.version                                              
     190 B │       -4 B │       6 B │        0 B │ ∆ META-INF/androidx.window.extensions.core_core.version                                      
     182 B │       -4 B │       6 B │        0 B │ ∆ META-INF/kotlinx_coroutines_play_services.version                                          
   1.1 KiB │       +4 B │     964 B │        0 B │ ∆ junit/runner/logo.gif                                                                      
     379 B │       -4 B │     281 B │        0 B │ ∆ res/Dd.png                                                                                 
   3.1 KiB │       +4 B │     3 KiB │        0 B │ ∆ res/MO.webp                                                                                
     323 B │       -4 B │     221 B │        0 B │ ∆ res/xa.9.png                                                                               
     179 B │       +2 B │       7 B │        0 B │ ∆ META-INF/androidx.activity_activity-ktx.version                                            
     171 B │       +2 B │       7 B │        0 B │ ∆ META-INF/androidx.activity_activity.version                                                
     170 B │       -2 B │       6 B │        0 B │ ∆ META-INF/androidx.autofill_autofill.version                                                
     200 B │       -2 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.animation_animation-core.version                                 
     208 B │       -2 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.foundation_foundation-layout.version                             
     190 B │       +2 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.material3_material3.version                                      
     208 B │       -2 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.material_material-icons-core.version                             
     200 B │       -2 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.material_material-ripple.version                                 
     200 B │       -2 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.runtime_runtime-saveable.version                                 
     180 B │       +2 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.ui_ui-geometry.version                                           
     180 B │       +2 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.ui_ui-graphics.version                                           
     172 B │       +2 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.ui_ui-text.version                                               
     172 B │       +2 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.ui_ui-unit.version                                               
     172 B │       +2 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.ui_ui-util.version                                               
     155 B │       +2 B │       7 B │        0 B │ ∆ META-INF/androidx.core_core.version                                                        
     184 B │       -2 B │       6 B │        0 B │ ∆ META-INF/androidx.datastore_datastore-core.version                                         
     180 B │       +2 B │       6 B │        0 B │ ∆ META-INF/androidx.graphics_graphics-path.version                                           
     200 B │       -2 B │       6 B │        0 B │ ∆ META-INF/androidx.legacy_legacy-support-core-utils.version                                 
     192 B │       -2 B │       6 B │        0 B │ ∆ META-INF/androidx.lifecycle_lifecycle-livedata.version                                     
     216 B │       -2 B │       6 B │        0 B │ ∆ META-INF/androidx.lifecycle_lifecycle-viewmodel-savedstate.version                         
     200 B │       -2 B │       6 B │        0 B │ ∆ META-INF/androidx.navigation_navigation-common-ktx.version                                 
     192 B │       -2 B │       6 B │        0 B │ ∆ META-INF/androidx.navigation_navigation-common.version                                     
     219 B │       +2 B │      13 B │        0 B │ ∆ META-INF/androidx.privacysandbox.ads_ads-adservices-java.version                           
     209 B │       -2 B │      13 B │        0 B │ ∆ META-INF/androidx.privacysandbox.ads_ads-adservices.version                                
     202 B │       -2 B │       6 B │        0 B │ ∆ META-INF/androidx.profileinstaller_profileinstaller.version                                
     172 B │       +2 B │       6 B │        0 B │ ∆ META-INF/androidx.window_window-core.version                                               
     171 B │       +2 B │       7 B │        0 B │ ∆ META-INF/androidx.work_work-runtime.version                                                
     165 B │       -2 B │       5 B │        0 B │ ∆ META-INF/com.google.dagger_dagger.version                                                  
     170 B │       -2 B │       6 B │        0 B │ ∆ META-INF/kotlinx_coroutines_android.version                                                
     164 B │       +2 B │       6 B │        0 B │ ∆ META-INF/kotlinx_coroutines_core.version                                                   
     878 B │       +2 B │     776 B │        0 B │ ∆ res/Qd.9.png                                                                               
     271 B │       -1 B │     120 B │        0 B │ ∆ META-INF/version-control-info.textproto                                                    
   4.2 KiB │       -1 B │  20.6 KiB │        0 B │ ∆ AndroidManifest.xml                                                                        
     194 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.foundation_foundation.version                                    
     186 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.material_material.version                                        
     194 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.ui_ui-tooling-preview.version                                    
     162 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.compose.ui_ui.version                                                    
     163 B │        0 B │       7 B │        0 B │ ∆ META-INF/androidx.core_core-ktx.version                                                    
     178 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.customview_customview.version                                            
     186 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.documentfile_documentfile.version                                        
     162 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.emoji2_emoji2.version                                                    
     170 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.fragment_fragment.version                                                
     186 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.interpolator_interpolator.version                                        
     210 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.lifecycle_lifecycle-livedata-core-ktx.version                            
     202 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.lifecycle_lifecycle-livedata-core.version                                
     210 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.lifecycle_lifecycle-viewmodel-compose.version                            
     202 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.lifecycle_lifecycle-viewmodel-ktx.version                                
     194 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.lifecycle_lifecycle-viewmodel.version                                    
     162 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.loader_loader.version                                                    
     194 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.navigation_navigation-compose.version                                    
     202 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.navigation_navigation-runtime-ktx.version                                
     194 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.navigation_navigation-runtime.version                                    
     162 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.room_room-ktx.version                                                    
     170 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.room_room-runtime.version                                                
     186 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.savedstate_savedstate-ktx.version                                        
     178 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.savedstate_savedstate.version                                            
     162 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.sqlite_sqlite.version                                                    
     162 B │        0 B │       6 B │        0 B │ ∆ META-INF/androidx.window_window.version                                                    
     179 B │        0 B │       7 B │        0 B │ ∆ META-INF/androidx.work_work-runtime-ktx.version                                            
───────────┼────────────┼───────────┼────────────┼──────────────────────────────────────────────────────────────────────────────────────────────
   5.9 MiB │  -25.7 MiB │   5.9 MiB │  -25.7 MiB │ (total)                                                                                      


======================
====   MANIFEST   ====
======================

              │ old                      │ new                      
──────────────┼──────────────────────────┼──────────────────────────
 package      │ dev.hossain.remotenotify │ dev.hossain.remotenotify 
 version code │ 5                        │ 6                        
 version name │ 1.4                      │ 1.5                      

@@ -3,4 +3,4 @@
     android:compileSdkVersionCodename="15"
-    android:versionCode="5"
-    android:versionName="1.4"
+    android:versionCode="6"
+    android:versionName="1.5"
     package="dev.hossain.remotenotify"

```