### PR TITLE
[FIXED] Added UI to guide user to skip battery optimization

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalert/BatteryOptimizationBottomSheet.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalert/BatteryOptimizationBottomSheet.kt
@@ -106,7 +106,7 @@ private fun BatteryOptimizationUi(onSettingsClick: () -> Unit) {
             Text("Open Settings")
         }
 
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(8.dp))
     }
 }
 

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalert/BatteryOptimizationBottomSheet.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalert/BatteryOptimizationBottomSheet.kt
@@ -1,0 +1,122 @@
+package dev.hossain.remotenotify.ui.addalert
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewDynamicColors
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import dev.hossain.remotenotify.R
+import dev.hossain.remotenotify.theme.ComposeAppTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BatteryOptimizationBottomSheet(
+    sheetState: SheetState,
+    onSettingsClick: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        modifier = modifier,
+    ) {
+        BatteryOptimizationUi(onSettingsClick)
+    }
+}
+
+@Composable
+private fun BatteryOptimizationUi(onSettingsClick: () -> Unit) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        // Icon and Title
+        Icon(
+            painter = painterResource(id = R.drawable.battery_5_bar_24dp),
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text = "Battery Optimization",
+            style = MaterialTheme.typography.titleLarge,
+        )
+
+        // Description
+        Text(
+            text = "For reliable background monitoring, this app needs to be excluded from battery optimization.",
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+        )
+
+        val appName = stringResource(id = R.string.app_name)
+
+        // Steps
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(
+                text = "How to disable battery optimization:",
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Text("1. Open device Settings")
+            Text("2. Go to Apps > Select '$appName'")
+            Text("3. Select 'Battery'")
+            Text("4. Choose 'Unrestricted' or 'Not optimized'")
+        }
+
+        // Action Button
+        FilledTonalButton(
+            onClick = onSettingsClick,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Icon(
+                Icons.Default.Settings,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Open Settings")
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+    }
+}
+
+@Composable
+@PreviewLightDark
+@PreviewDynamicColors
+private fun PreviewBatteryOptimizationUi() {
+    ComposeAppTheme {
+        Surface {
+            BatteryOptimizationUi {}
+        }
+    }
+}

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalert/BatteryOptimizationCard.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalert/BatteryOptimizationCard.kt
@@ -2,6 +2,8 @@ package dev.hossain.remotenotify.ui.addalert
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -14,11 +16,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewDynamicColors
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
-import dev.hossain.remotenotify.R
 import dev.hossain.remotenotify.theme.ComposeAppTheme
 
 @Composable
@@ -36,7 +36,7 @@ internal fun BatteryOptimizationCard(
         ListItem(
             headlineContent = {
                 Text(
-                    "Enable More Reliable Checks",
+                    "Reliable Checks",
                     style = MaterialTheme.typography.titleMedium,
                 )
             },
@@ -48,7 +48,7 @@ internal fun BatteryOptimizationCard(
             },
             leadingContent = {
                 Icon(
-                    painter = painterResource(id = R.drawable.battery_5_bar_24dp),
+                    imageVector = Icons.Default.Info,
                     contentDescription = null,
                     modifier = Modifier.size(24.dp),
                     tint = MaterialTheme.colorScheme.primary,

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalert/BatteryOptimizationCard.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalert/BatteryOptimizationCard.kt
@@ -1,0 +1,77 @@
+package dev.hossain.remotenotify.ui.addalert
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewDynamicColors
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import dev.hossain.remotenotify.R
+import dev.hossain.remotenotify.theme.ComposeAppTheme
+
+@Composable
+internal fun BatteryOptimizationCard(
+    onOptimizeClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            ),
+    ) {
+        ListItem(
+            headlineContent = {
+                Text(
+                    "Enable More Reliable Checks",
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            },
+            supportingContent = {
+                Text(
+                    "For more reliable monitoring, disable battery optimization for this app",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            },
+            leadingContent = {
+                Icon(
+                    painter = painterResource(id = R.drawable.battery_5_bar_24dp),
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            },
+            trailingContent = {
+                Button(
+                    onClick = onOptimizeClick,
+                ) {
+                    Text("Optimize")
+                }
+            },
+        )
+    }
+}
+
+@Composable
+@PreviewLightDark
+@PreviewDynamicColors
+private fun PreviewBatteryOptimizationCard() {
+    ComposeAppTheme {
+        Surface {
+            BatteryOptimizationCard({})
+        }
+    }
+}

--- a/app/src/main/java/dev/hossain/remotenotify/utils/BatteryOptimizationHelper.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/utils/BatteryOptimizationHelper.kt
@@ -1,0 +1,19 @@
+package dev.hossain.remotenotify.utils
+
+import android.content.Context
+import android.os.PowerManager
+
+/**
+ * Helper class to check if app is ignoring battery optimizations.
+ *
+ * - https://developer.android.com/training/monitoring-device-state/doze-standby.html
+ */
+object BatteryOptimizationHelper {
+    /**
+     * - https://developer.android.com/reference/android/os/PowerManager#isIgnoringBatteryOptimizations(java.lang.String)
+     */
+    fun isIgnoringBatteryOptimizations(context: Context): Boolean {
+        val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        return powerManager.isIgnoringBatteryOptimizations(context.packageName)
+    }
+}

--- a/app/src/main/java/dev/hossain/remotenotify/utils/ContextExt.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/utils/ContextExt.kt
@@ -1,0 +1,16 @@
+package dev.hossain.remotenotify.utils
+
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.activity.ComponentActivity
+
+fun Context.findActivity(): ComponentActivity? {
+    var currentContext = this
+    while (currentContext is ContextWrapper) {
+        if (currentContext is ComponentActivity) {
+            return currentContext
+        }
+        currentContext = currentContext.baseContext
+    }
+    return null
+}


### PR DESCRIPTION
Fixes #141


https://github.com/user-attachments/assets/dcba0fc7-d20d-4e9d-b06b-4a18784045ee

----

This pull request introduces a feature to handle battery optimization settings within the `AddNewRemoteAlert` screen. The changes include new UI components, state management, and utility functions to support this feature.

### Battery Optimization Feature:

* **State Management and Events:**
  - Added new state variables `showBatteryOptSheet` and `isBatteryOptimized` to `AddNewRemoteAlertScreen.State`.
  - Introduced new events `ShowBatteryOptimizationSheet`, `DismissBatteryOptimizationSheet`, and `OpenBatterySettings` to handle user interactions.
  - Updated `AddNewRemoteAlertPresenter` to manage the new state variables and handle the new events. [[1]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fL81-R124) [[2]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR135-R148)

* **UI Components:**
  - Created `BatteryOptimizationBottomSheet` to display a modal bottom sheet with instructions and a button to open battery settings.
  - Added `BatteryOptimizationCard` to prompt the user to disable battery optimization if it is enabled.
  - Updated `AddNewRemoteAlertUi` to include the new `BatteryOptimizationCard` and handle the display of the `BatteryOptimizationBottomSheet`. [[1]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR314-R336) [[2]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR391-R392)

* **Utility Functions:**
  - Added `BatteryOptimizationHelper` to check if the app is ignoring battery optimizations.
  - Introduced `ContextExt.kt` with a function to find the current activity from a context.

* **Imports and Dependencies:**
  - Updated imports in `AddNewRemoteAlert.kt` to include necessary Android and Compose libraries. [[1]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR3-L10) [[2]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR29-R45)