### PR TITLE
[UX/UX] Improve the log list

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/db/AlertCheckLogDao.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/db/AlertCheckLogDao.kt
@@ -3,6 +3,7 @@ package dev.hossain.remotenotify.db
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
+import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -57,4 +58,13 @@ interface AlertCheckLogDao {
     """,
     )
     fun getLatestCheckLog(): Flow<AlertCheckLogEntity?>
+
+    @Transaction
+    @Query(
+        """
+        SELECT * FROM alert_check_log
+        ORDER BY checked_at DESC
+    """,
+    )
+    fun getAllLogsWithConfig(): Flow<List<AlertLogWithConfig>>
 }

--- a/app/src/main/java/dev/hossain/remotenotify/db/AlertLogWithConfig.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/db/AlertLogWithConfig.kt
@@ -1,0 +1,13 @@
+package dev.hossain.remotenotify.db
+
+import androidx.room.Embedded
+import androidx.room.Relation
+
+data class AlertLogWithConfig(
+    @Embedded val log: AlertCheckLogEntity,
+    @Relation(
+        parentColumn = "alert_config_id",
+        entityColumn = "id",
+    )
+    val config: AlertConfigEntity,
+)

--- a/app/src/main/java/dev/hossain/remotenotify/model/AlertCheckLog.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/model/AlertCheckLog.kt
@@ -1,12 +1,19 @@
 package dev.hossain.remotenotify.model
 
 import dev.hossain.remotenotify.db.AlertCheckLogEntity
+import dev.hossain.remotenotify.db.AlertLogWithConfig
+import dev.hossain.remotenotify.notifier.NotifierType
 
 data class AlertCheckLog(
     val checkedOn: Long,
     val alertType: AlertType,
     val isAlertSent: Boolean,
+    val notifierType: NotifierType?,
     val stateValue: Int,
+    val configId: Long,
+    val configBatteryPercentage: Int,
+    val configStorageMinSpaceGb: Int,
+    val configCreatedOn: Long,
 )
 
 fun AlertCheckLogEntity.toAlertCheckLog(): AlertCheckLog =
@@ -14,5 +21,23 @@ fun AlertCheckLogEntity.toAlertCheckLog(): AlertCheckLog =
         checkedOn = checkedAt,
         alertType = alertType,
         isAlertSent = alertTriggered,
+        notifierType = notifierType,
         stateValue = alertStateValue,
+        configId = 0,
+        configBatteryPercentage = 0,
+        configStorageMinSpaceGb = 0,
+        configCreatedOn = 0,
+    )
+
+fun AlertLogWithConfig.toAlertCheckLog(): AlertCheckLog =
+    AlertCheckLog(
+        checkedOn = log.checkedAt,
+        alertType = log.alertType,
+        isAlertSent = log.alertTriggered,
+        notifierType = log.notifierType,
+        stateValue = log.alertStateValue,
+        configId = config.id,
+        configBatteryPercentage = config.batteryPercentage,
+        configStorageMinSpaceGb = config.storageMinSpaceGb,
+        configCreatedOn = config.createdOn,
     )

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlert.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlert.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
@@ -186,6 +188,7 @@ fun AddNewRemoteAlertUi(
                 Modifier
                     .padding(innerPadding)
                     .padding(16.dp)
+                    .verticalScroll(rememberScrollState())
                     .fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(24.dp),
         ) {

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertchecklog/AlertCheckLogViewerScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertchecklog/AlertCheckLogViewerScreen.kt
@@ -58,6 +58,7 @@ import dev.hossain.remotenotify.model.toAlertCheckLog
 import dev.hossain.remotenotify.notifier.NotifierType
 import dev.hossain.remotenotify.theme.ComposeAppTheme
 import dev.hossain.remotenotify.utils.formatTimeDuration
+import dev.hossain.remotenotify.utils.toTitleCase
 import kotlinx.coroutines.flow.map
 import kotlinx.parcelize.Parcelize
 
@@ -230,11 +231,20 @@ private fun LogItemCard(log: AlertCheckLog) {
             },
             supportingContent = {
                 Column {
+                    // Show configured threshold and actual value
                     Text(
                         text =
                             when (log.alertType) {
-                                AlertType.BATTERY -> "${log.stateValue}% battery was remaining"
-                                AlertType.STORAGE -> "${log.stateValue} GB storage was remaining"
+                                AlertType.BATTERY ->
+                                    buildString {
+                                        append("${log.stateValue}% battery")
+                                        append(" (Alert threshold: ${log.configBatteryPercentage}%)")
+                                    }
+                                AlertType.STORAGE ->
+                                    buildString {
+                                        append("${log.stateValue} GB storage")
+                                        append(" (Alert threshold: ${log.configStorageMinSpaceGb} GB)")
+                                    }
                             },
                         style = MaterialTheme.typography.bodyMedium,
                     )
@@ -245,21 +255,25 @@ private fun LogItemCard(log: AlertCheckLog) {
                     )
 
                     Spacer(modifier = Modifier.height(4.dp))
-                    Text(
-                        text =
-                            if (log.isAlertSent) {
-                                "Alert triggered & sent notifications"
-                            } else {
-                                "Alert not triggered"
-                            },
-                        style = MaterialTheme.typography.bodySmall,
-                        color =
-                            if (log.isAlertSent) {
-                                MaterialTheme.colorScheme.error
-                            } else {
-                                MaterialTheme.colorScheme.onSurfaceVariant
-                            },
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text =
+                                if (log.isAlertSent) {
+                                    "Alert triggered & sent via ${log.notifierType?.name?.toTitleCase() ?: "N/A"}"
+                                } else {
+                                    "Alert not triggered"
+                                },
+                            style = MaterialTheme.typography.bodySmall,
+                            color =
+                                if (log.isAlertSent) {
+                                    MaterialTheme.colorScheme.error
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                },
+                        )
+                    }
                 }
             },
             leadingContent = {

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertchecklog/AlertCheckLogViewerScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertchecklog/AlertCheckLogViewerScreen.kt
@@ -54,6 +54,8 @@ import dev.hossain.remotenotify.db.AlertCheckLogDao
 import dev.hossain.remotenotify.di.AppScope
 import dev.hossain.remotenotify.model.AlertCheckLog
 import dev.hossain.remotenotify.model.AlertType
+import dev.hossain.remotenotify.model.toAlertCheckLog
+import dev.hossain.remotenotify.notifier.NotifierType
 import dev.hossain.remotenotify.theme.ComposeAppTheme
 import dev.hossain.remotenotify.utils.formatTimeDuration
 import kotlinx.coroutines.flow.map
@@ -96,15 +98,10 @@ class AlertCheckLogViewerPresenter
 
             val logs by produceState<List<AlertCheckLog>>(emptyList()) {
                 alertCheckLogDao
-                    .getAllCheckLogs()
+                    .getAllLogsWithConfig()
                     .map { entities ->
                         entities.map { entity ->
-                            AlertCheckLog(
-                                checkedOn = entity.checkedAt,
-                                alertType = entity.alertType,
-                                isAlertSent = entity.alertTriggered,
-                                stateValue = entity.alertStateValue,
-                            )
+                            entity.toAlertCheckLog()
                         }
                     }.collect {
                         value = it
@@ -234,17 +231,19 @@ private fun LogItemCard(log: AlertCheckLog) {
             supportingContent = {
                 Column {
                     Text(
-                        text = formatTimeDuration(log.checkedOn),
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                    Text(
                         text =
                             when (log.alertType) {
-                                AlertType.BATTERY -> "${log.stateValue}% battery remaning"
-                                AlertType.STORAGE -> "${log.stateValue} GB storage remaining"
+                                AlertType.BATTERY -> "${log.stateValue}% battery was remaining"
+                                AlertType.STORAGE -> "${log.stateValue} GB storage was remaining"
                             },
                         style = MaterialTheme.typography.bodyMedium,
                     )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "Checked ${formatTimeDuration(log.checkedOn)}",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
                         text =
@@ -353,25 +352,45 @@ private fun PreviewAlertCheckLogViewerUi() {
                 checkedOn = System.currentTimeMillis() - 3600000, // 1 hour ago
                 alertType = AlertType.BATTERY,
                 isAlertSent = true,
+                notifierType = NotifierType.EMAIL,
                 stateValue = 15,
+                configId = 1,
+                configBatteryPercentage = 20,
+                configStorageMinSpaceGb = 0,
+                configCreatedOn = System.currentTimeMillis() - 86400000 * 7, // 7 days ago
             ),
             AlertCheckLog(
                 checkedOn = System.currentTimeMillis() - 7200000, // 2 hours ago
                 alertType = AlertType.STORAGE,
                 isAlertSent = false,
+                notifierType = null,
                 stateValue = 20,
+                configId = 2,
+                configBatteryPercentage = 0,
+                configStorageMinSpaceGb = 25,
+                configCreatedOn = System.currentTimeMillis() - 86400000 * 5, // 5 days ago
             ),
             AlertCheckLog(
                 checkedOn = System.currentTimeMillis() - 86400000, // 1 day ago
                 alertType = AlertType.BATTERY,
                 isAlertSent = false,
+                notifierType = null,
                 stateValue = 80,
+                configId = 1,
+                configBatteryPercentage = 20,
+                configStorageMinSpaceGb = 0,
+                configCreatedOn = System.currentTimeMillis() - 86400000 * 7, // 7 days ago
             ),
             AlertCheckLog(
                 checkedOn = System.currentTimeMillis() - 9250000,
                 alertType = AlertType.STORAGE,
                 isAlertSent = true,
+                notifierType = NotifierType.TELEGRAM,
                 stateValue = 2,
+                configId = 2,
+                configBatteryPercentage = 0,
+                configStorageMinSpaceGb = 25,
+                configCreatedOn = System.currentTimeMillis() - 86400000 * 5, // 5 days ago
             ),
         )
 

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
@@ -66,6 +66,7 @@ import dev.hossain.remotenotify.model.WorkerStatus
 import dev.hossain.remotenotify.monitor.BatteryMonitor
 import dev.hossain.remotenotify.monitor.StorageMonitor
 import dev.hossain.remotenotify.notifier.NotificationSender
+import dev.hossain.remotenotify.notifier.NotifierType
 import dev.hossain.remotenotify.ui.about.AboutAppScreen
 import dev.hossain.remotenotify.ui.addalert.AddNewRemoteAlertScreen
 import dev.hossain.remotenotify.ui.alertchecklog.AlertCheckLogViewerScreen
@@ -559,7 +560,12 @@ private fun PreviewAlertsListUiWithLastCheck() {
                         checkedOn = System.currentTimeMillis() - 300_000, // 5 minutes ago
                         alertType = AlertType.BATTERY,
                         isAlertSent = true,
+                        notifierType = NotifierType.TELEGRAM,
                         stateValue = 12,
+                        configId = 1L,
+                        configBatteryPercentage = 20,
+                        configStorageMinSpaceGb = 0,
+                        configCreatedOn = System.currentTimeMillis() - 86400000, // 1 day ago
                     ),
                 workerStatus = WorkerStatus("RUNNING", 0, 0),
                 showEducationSheet = false,

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/LastCheckStatusCardUi.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/LastCheckStatusCardUi.kt
@@ -28,6 +28,7 @@ import dev.hossain.remotenotify.model.AlertCheckLog
 import dev.hossain.remotenotify.model.AlertType
 import dev.hossain.remotenotify.model.WorkerStatus
 import dev.hossain.remotenotify.model.toIconResId
+import dev.hossain.remotenotify.notifier.NotifierType
 import dev.hossain.remotenotify.theme.ComposeAppTheme
 import dev.hossain.remotenotify.utils.formatTimeDuration
 import dev.hossain.remotenotify.utils.toTitleCase
@@ -162,10 +163,15 @@ private fun PreviewLastCheckStatusCard() {
                 LastCheckStatusCardUi(
                     lastCheckLog =
                         AlertCheckLog(
-                            checkedOn = System.currentTimeMillis(),
+                            checkedOn = System.currentTimeMillis() - 300_000, // 5 minutes ago
                             alertType = AlertType.BATTERY,
-                            isAlertSent = false,
-                            stateValue = 17,
+                            isAlertSent = true,
+                            notifierType = NotifierType.TELEGRAM,
+                            stateValue = 12,
+                            configId = 1L,
+                            configBatteryPercentage = 20,
+                            configStorageMinSpaceGb = 0,
+                            configCreatedOn = System.currentTimeMillis() - 86400000, // 1 day ago
                         ),
                     workerStatus =
                         WorkerStatus(
@@ -180,10 +186,15 @@ private fun PreviewLastCheckStatusCard() {
                 LastCheckStatusCardUi(
                     lastCheckLog =
                         AlertCheckLog(
-                            checkedOn = System.currentTimeMillis() - 10_00_000,
+                            checkedOn = System.currentTimeMillis() - 300_000, // 5 minutes ago
                             alertType = AlertType.STORAGE,
-                            isAlertSent = false,
+                            isAlertSent = true,
+                            notifierType = NotifierType.WEBHOOK_REST_API,
                             stateValue = 12,
+                            configId = 1L,
+                            configBatteryPercentage = 0,
+                            configStorageMinSpaceGb = 16,
+                            configCreatedOn = System.currentTimeMillis() - 86400000, // 1 day ago
                         ),
                     workerStatus =
                         WorkerStatus(

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/LastCheckStatusCardUi.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/LastCheckStatusCardUi.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewDynamicColors
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
-import dev.hossain.remotenotify.BuildConfig
 import dev.hossain.remotenotify.R
 import dev.hossain.remotenotify.model.AlertCheckLog
 import dev.hossain.remotenotify.model.AlertType
@@ -140,16 +139,14 @@ internal fun LastCheckStatusCardUi(
                 }
             }
 
-            if (BuildConfig.DEBUG) {
-                TextButton(
-                    onClick = onViewAllLogs,
-                    colors =
-                        ButtonDefaults.textButtonColors(
-                            contentColor = MaterialTheme.colorScheme.primary,
-                        ),
-                ) {
-                    Text("View All Logs")
-                }
+            TextButton(
+                onClick = onViewAllLogs,
+                colors =
+                    ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.primary,
+                    ),
+            ) {
+                Text("View All Logs")
             }
         }
     }

--- a/app/src/main/res/drawable/format_list_bulleted_24dp.xml
+++ b/app/src/main/res/drawable/format_list_bulleted_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M360,760v-80h480v80L360,760ZM360,520v-80h480v80L360,520ZM360,280v-80h480v80L360,280ZM200,800q-33,0 -56.5,-23.5T120,720q0,-33 23.5,-56.5T200,640q33,0 56.5,23.5T280,720q0,33 -23.5,56.5T200,800ZM200,560q-33,0 -56.5,-23.5T120,480q0,-33 23.5,-56.5T200,400q33,0 56.5,23.5T280,480q0,33 -23.5,56.5T200,560ZM200,320q-33,0 -56.5,-23.5T120,240q0,-33 23.5,-56.5T200,160q33,0 56.5,23.5T280,240q0,33 -23.5,56.5T200,320Z"
+      android:fillColor="#e8eaed"/>
+</vector>

--- a/app/src/main/res/drawable/list_24dp.xml
+++ b/app/src/main/res/drawable/list_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:pathData="M280,360v-80h560v80L280,360ZM280,520v-80h560v80L280,520ZM280,680v-80h560v80L280,680ZM160,360q-17,0 -28.5,-11.5T120,320q0,-17 11.5,-28.5T160,280q17,0 28.5,11.5T200,320q0,17 -11.5,28.5T160,360ZM160,520q-17,0 -28.5,-11.5T120,480q0,-17 11.5,-28.5T160,440q17,0 28.5,11.5T200,480q0,17 -11.5,28.5T160,520ZM160,680q-17,0 -28.5,-11.5T120,640q0,-17 11.5,-28.5T160,600q17,0 28.5,11.5T200,640q0,17 -11.5,28.5T160,680Z"
+      android:fillColor="#e8eaed"/>
+</vector>


### PR DESCRIPTION
* #154

| Before | After |
| ----- | ----- |
| <img width="405" alt="Screenshot 2025-02-22 at 1 00 24 PM" src="https://github.com/user-attachments/assets/bee17494-5760-4648-93fd-1eb9da92f74a" /> | <img width="404" alt="Screenshot 2025-02-22 at 12 59 46 PM" src="https://github.com/user-attachments/assets/a4f41be2-85ca-4c3b-b4ce-23f067bf0295" /> |


This pull request includes several changes to the database layer, UI components, and data models to enhance the functionality and user experience of the alert notification system. The most important changes are grouped by theme below:

### Database Enhancements:
* Added a new `AlertLogWithConfig` data class to support fetching logs with their configurations. (`app/src/main/java/dev/hossain/remotenotify/db/AlertLogWithConfig.kt`)
* Updated `AlertCheckLogDao` to include a new query method `getAllLogsWithConfig` that retrieves all logs along with their configurations using a `@Transaction` annotation. (`app/src/main/java/dev/hossain/remotenotify/db/AlertCheckLogDao.kt`) [[1]](diffhunk://#diff-47b8cce5ab1b4ed9c9cd917e5ae75de499100c8bd2c1ea4f5da1423f7869a13eR6) [[2]](diffhunk://#diff-47b8cce5ab1b4ed9c9cd917e5ae75de499100c8bd2c1ea4f5da1423f7869a13eR61-R69)

### UI Improvements:
* Enhanced the `AddNewRemoteAlert` screen to support vertical scrolling, improving the user experience when adding new alerts. (`app/src/main/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlert.kt`) [[1]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR12-R13) [[2]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR191)
* Updated the `AlertCheckLogViewerScreen` to display detailed log information, including configured thresholds, actual values, and notifier types. Added a new `LogsSummaryInfo` composable to show a summary of logs and check intervals. (`app/src/main/java/dev/hossain/remotenotify/ui/alertchecklog/AlertCheckLogViewerScreen.kt`) [[1]](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceR8-R15) [[2]](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceR52-R61) [[3]](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceR74) [[4]](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceR87-R105) [[5]](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceL107-R122) [[6]](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceL135-L140) [[7]](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceR188-R194) [[8]](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceL222-R264) [[9]](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceR277) [[10]](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceR301-R359) [[11]](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceR369-R407) [[12]](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceR417)

### Data Model Updates:
* Extended the `AlertCheckLog` data model to include additional fields such as `notifierType`, `configId`, `configBatteryPercentage`, `configStorageMinSpaceGb`, and `configCreatedOn`. Updated the conversion functions to map the new fields. (`app/src/main/java/dev/hossain/remotenotify/model/AlertCheckLog.kt`)

### Codebase Maintenance:
* Minor refactoring and import adjustments across various files to support the new features and improve code readability. (`app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt`) [[1]](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577R69) [[2]](diffhunk://#diff-15744744fa1b40dafd97437a3798db508f246ccbe23c07d6029b562d312d8577R563-R568) (`app/src/main/java/dev/hossain/remotenotify/ui/alertlist/LastCheckStatusCardUi.kt`) [[3]](diffhunk://#diff-caf456d5149228be00a7aaaadd095cd2e48a880edd5465acc335ebfe72971901L26-R31) [[4]](diffhunk://#diff-caf456d5149228be00a7aaaadd095cd2e48a880edd5465acc335ebfe72971901L143)