### PR TITLE
[REFACTOR] Removed DAO usage directly in the screen

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/data/RemoteAlertRepository.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/RemoteAlertRepository.kt
@@ -34,9 +34,11 @@ interface RemoteAlertRepository {
         notifierType: NotifierType?,
     )
 
-    fun getLatestCheckForAlert(alertId: Long): Flow<AlertCheckLogEntity?>
+    fun getLatestCheckForAlert(alertId: Long): Flow<AlertCheckLog?>
 
     fun getLatestCheckLog(): Flow<AlertCheckLog?>
+
+    fun getAllAlertCheckLogs(): Flow<List<AlertCheckLog>>
 }
 
 @ContributesBinding(AppScope::class)
@@ -83,8 +85,21 @@ class RemoteAlertRepositoryImpl
             )
         }
 
-        // TODO - do not expose entity directly
-        override fun getLatestCheckForAlert(alertId: Long): Flow<AlertCheckLogEntity?> = alertCheckLogDao.getLatestCheckForAlert(alertId)
+        override fun getLatestCheckForAlert(alertId: Long): Flow<AlertCheckLog?> =
+            alertCheckLogDao
+                .getLatestCheckForAlert(alertId)
+                .map { it?.toAlertCheckLog() }
 
-        override fun getLatestCheckLog(): Flow<AlertCheckLog?> = alertCheckLogDao.getLatestCheckLog().map { it?.toAlertCheckLog() }
+        override fun getLatestCheckLog(): Flow<AlertCheckLog?> =
+            alertCheckLogDao
+                .getLatestCheckLog()
+                .map { it?.toAlertCheckLog() }
+
+        override fun getAllAlertCheckLogs(): Flow<List<AlertCheckLog>> =
+            alertCheckLogDao
+                .getAllLogsWithConfig()
+                .map { logEntityList ->
+                    logEntityList
+                        .map { alertCheckLogEntity -> alertCheckLogEntity.toAlertCheckLog() }
+                }
     }

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertchecklog/AlertCheckLogViewerScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertchecklog/AlertCheckLogViewerScreen.kt
@@ -50,16 +50,14 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dev.hossain.remotenotify.R
 import dev.hossain.remotenotify.data.AppPreferencesDataStore
-import dev.hossain.remotenotify.db.AlertCheckLogDao
+import dev.hossain.remotenotify.data.RemoteAlertRepository
 import dev.hossain.remotenotify.di.AppScope
 import dev.hossain.remotenotify.model.AlertCheckLog
 import dev.hossain.remotenotify.model.AlertType
-import dev.hossain.remotenotify.model.toAlertCheckLog
 import dev.hossain.remotenotify.notifier.NotifierType
 import dev.hossain.remotenotify.theme.ComposeAppTheme
 import dev.hossain.remotenotify.utils.formatTimeDuration
 import dev.hossain.remotenotify.utils.toTitleCase
-import kotlinx.coroutines.flow.map
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -85,7 +83,7 @@ class AlertCheckLogViewerPresenter
     constructor(
         @Assisted private val navigator: Navigator,
         private val appPreferencesDataStore: AppPreferencesDataStore,
-        private val alertCheckLogDao: AlertCheckLogDao,
+        private val remoteAlertRepository: RemoteAlertRepository,
     ) : Presenter<AlertCheckLogViewerScreen.State> {
         @Composable
         override fun present(): AlertCheckLogViewerScreen.State {
@@ -98,13 +96,9 @@ class AlertCheckLogViewerPresenter
             }
 
             val logs by produceState<List<AlertCheckLog>>(emptyList()) {
-                alertCheckLogDao
-                    .getAllLogsWithConfig()
-                    .map { entities ->
-                        entities.map { entity ->
-                            entity.toAlertCheckLog()
-                        }
-                    }.collect {
+                remoteAlertRepository
+                    .getAllAlertCheckLogs()
+                    .collect {
                         value = it
                         isLoading = false
                     }


### PR DESCRIPTION
Use repo instead. For
* #154

This pull request includes significant changes to the `RemoteAlertRepository` interface and its implementation, as well as updates to the `AlertCheckLogViewerScreen` to use the new repository methods. The most important changes are detailed below:

### Repository Interface and Implementation:

* Modified the `RemoteAlertRepository` interface to return `Flow<AlertCheckLog?>` instead of `Flow<AlertCheckLogEntity?>` for the `getLatestCheckForAlert` method and added a new method `getAllAlertCheckLogs` to retrieve all alert check logs.
* Updated the `RemoteAlertRepositoryImpl` class to map `AlertCheckLogEntity` to `AlertCheckLog` in the `getLatestCheckForAlert` and `getLatestCheckLog` methods, and implemented the new `getAllAlertCheckLogs` method to map a list of entities to their corresponding models.

### UI Updates:

* Replaced the `AlertCheckLogDao` with `RemoteAlertRepository` in the `AlertCheckLogViewerPresenter` class to use the new repository methods for fetching alert check logs. [[1]](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceL88-R86) [[2]](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceL101-R101)
* Updated imports in the `AlertCheckLogViewerScreen` to reflect the changes in the data source.
