### PR TITLE
[FIXED] Key issue, removed it for now.

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertchecklog/AlertCheckLogViewerScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertchecklog/AlertCheckLogViewerScreen.kt
@@ -188,7 +188,6 @@ fun AlertCheckLogViewerUi(
 
                     items(
                         count = state.logs.size,
-                        key = { state.logs[it].checkedOn },
                     ) { index ->
                         LogItemCard(
                             log = state.logs[index],


### PR DESCRIPTION
This pull request includes a small change to the `AlertCheckLogViewerScreen.kt` file. The change removes the `key` parameter from the `items` function in the `AlertCheckLogViewerUi` method.

* [`app/src/main/java/dev/hossain/remotenotify/ui/alertchecklog/AlertCheckLogViewerScreen.kt`](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceL191): Removed the `key` parameter from the `items` function call.