### PR TITLE
[UPDATE] Increase the limit of checker interval

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/NotificationMediumListScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/NotificationMediumListScreen.kt
@@ -172,8 +172,8 @@ class NotificationMediumListPresenter
             LaunchedEffect(Unit) {
                 // Set up debounced updates to avoid frequent worker setup
                 workerIntervalFlow
-                    // Wait for 500ms of inactivity
-                    .debounce(500L)
+                    // Wait for 1 second of inactivity
+                    .debounce(1_000L)
                     .collect { minutes ->
                         Timber.d("Worker interval updated: $minutes minutes")
                         appPreferencesDataStore.saveWorkerInterval(minutes)

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/WorkerCheckIntervalConfigUi.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/WorkerCheckIntervalConfigUi.kt
@@ -37,8 +37,8 @@ internal fun WorkerConfigCard(
     modifier: Modifier = Modifier,
 ) {
     var intervalSliderValue by remember { mutableFloatStateOf(state.workerIntervalMinutes.toFloat()) }
-    val valueRangeStart = 60f // 1 hour
-    val valueRangeEnd = 720f // 12 hours
+    val alertCheckIntervalRangeStart = 60f // 1 hour
+    val alertCheckIntervalRangeEnd = 720f // 12 hours
 
     Card(
         modifier = modifier,
@@ -83,7 +83,7 @@ internal fun WorkerConfigCard(
                     intervalSliderValue = intervalValue // Update UI immediately
                     state.eventSink(NotificationMediumListScreen.Event.OnWorkerIntervalUpdated(intervalValue.toLong()))
                 },
-                valueRange = valueRangeStart..valueRangeEnd,
+                valueRange = alertCheckIntervalRangeStart..alertCheckIntervalRangeEnd,
                 modifier = Modifier.fillMaxWidth(),
                 colors =
                     SliderDefaults.colors(
@@ -100,12 +100,12 @@ internal fun WorkerConfigCard(
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 Text(
-                    text = "${(valueRangeStart / 60).toInt()}h",
+                    text = "${(alertCheckIntervalRangeStart / 60).toInt()}h",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Text(
-                    text = "${(valueRangeEnd / 60).toInt()}h",
+                    text = "${(alertCheckIntervalRangeEnd / 60).toInt()}h",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/WorkerCheckIntervalConfigUi.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/WorkerCheckIntervalConfigUi.kt
@@ -37,6 +37,9 @@ internal fun WorkerConfigCard(
     modifier: Modifier = Modifier,
 ) {
     var intervalSliderValue by remember { mutableFloatStateOf(state.workerIntervalMinutes.toFloat()) }
+    val valueRangeStart = 60f // 1 hour
+    val valueRangeEnd = 720f // 12 hours
+
     Card(
         modifier = modifier,
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
@@ -80,8 +83,7 @@ internal fun WorkerConfigCard(
                     intervalSliderValue = intervalValue // Update UI immediately
                     state.eventSink(NotificationMediumListScreen.Event.OnWorkerIntervalUpdated(intervalValue.toLong()))
                 },
-                valueRange = 30f..300f,
-                // steps = 270, // (300-30)/1 to have steps of 1 minute
+                valueRange = valueRangeStart..valueRangeEnd,
                 modifier = Modifier.fillMaxWidth(),
                 colors =
                     SliderDefaults.colors(
@@ -98,12 +100,12 @@ internal fun WorkerConfigCard(
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 Text(
-                    text = "30m",
+                    text = "${(valueRangeStart / 60).toInt()}h",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Text(
-                    text = "5h",
+                    text = "${(valueRangeEnd / 60).toInt()}h",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/app/src/main/java/dev/hossain/remotenotify/worker/WorkerRequest.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/worker/WorkerRequest.kt
@@ -12,7 +12,7 @@ import androidx.work.WorkManager
 import androidx.work.WorkRequest
 import java.util.concurrent.TimeUnit
 
-internal const val DEFAULT_PERIODIC_INTERVAL_MINUTES = 60L
+internal const val DEFAULT_PERIODIC_INTERVAL_MINUTES = 120L
 internal const val DEVICE_VITALS_CHECKER_DEBUG_WORKER_ID = "onetime-debug-request"
 internal const val DEVICE_VITALS_CHECKER_WORKER_ID = "periodic-health-check"
 


### PR DESCRIPTION
This pull request includes updates to the worker configuration UI and changes to the default periodic interval for worker requests. The most important changes are as follows:

### Worker Configuration UI Updates:

* Updated the range of the interval slider in `WorkerConfigCard` to be from 1 hour to 12 hours instead of the previous 30 minutes to 5 hours (`app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/WorkerCheckIntervalConfigUi.kt`). [[1]](diffhunk://#diff-079cb9d22c8b22976e11a092c821b5d8cbeeee3ff92207adef943aae1266a2f7R40-R42) [[2]](diffhunk://#diff-079cb9d22c8b22976e11a092c821b5d8cbeeee3ff92207adef943aae1266a2f7L83-R86)
* Adjusted the text labels on the interval slider to reflect the new range in hours (`app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/WorkerCheckIntervalConfigUi.kt`).

### Worker Request Configuration:

* Changed the default periodic interval for worker requests from 60 minutes to 120 minutes (`app/src/main/java/dev/hossain/remotenotify/worker/WorkerRequest.kt`).