### PR TITLE
[ADDED] Don't remind me to optimize battery option

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/data/AppPreferencesDataStore.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/AppPreferencesDataStore.kt
@@ -27,7 +27,7 @@ class AppPreferencesDataStore
             private val WORKER_INTERVAL_KEY = longPreferencesKey("worker_interval_minutes")
             private val LAST_REVIEW_REQUEST_KEY = longPreferencesKey("last_review_request_time")
             private val FIRST_TIME_DIALOG_SHOWN = booleanPreferencesKey("first_time_dialog_shown")
-            private val HIDE_BATTERY_OPT_REMINDER = booleanPreferencesKey("hide_battery_opt_reminder")
+            private val HIDE_BATTERY_OPTIMIZATION_REMINDER = booleanPreferencesKey("hide_battery_optimization_reminder")
         }
 
         suspend fun saveWorkerInterval(intervalMinutes: Long) {
@@ -69,12 +69,12 @@ class AppPreferencesDataStore
         val hideBatteryOptReminder: Flow<Boolean> =
             context.appPreferencesDataStore.data
                 .map { preferences ->
-                    preferences[HIDE_BATTERY_OPT_REMINDER] ?: false
+                    preferences[HIDE_BATTERY_OPTIMIZATION_REMINDER] ?: false
                 }
 
         suspend fun setHideBatteryOptReminder(hide: Boolean) {
             context.appPreferencesDataStore.edit { preferences ->
-                preferences[HIDE_BATTERY_OPT_REMINDER] = hide
+                preferences[HIDE_BATTERY_OPTIMIZATION_REMINDER] = hide
             }
         }
     }

--- a/app/src/main/java/dev/hossain/remotenotify/data/AppPreferencesDataStore.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/AppPreferencesDataStore.kt
@@ -27,6 +27,7 @@ class AppPreferencesDataStore
             private val WORKER_INTERVAL_KEY = longPreferencesKey("worker_interval_minutes")
             private val LAST_REVIEW_REQUEST_KEY = longPreferencesKey("last_review_request_time")
             private val FIRST_TIME_DIALOG_SHOWN = booleanPreferencesKey("first_time_dialog_shown")
+            private val HIDE_BATTERY_OPT_REMINDER = booleanPreferencesKey("hide_battery_opt_reminder")
         }
 
         suspend fun saveWorkerInterval(intervalMinutes: Long) {
@@ -62,6 +63,18 @@ class AppPreferencesDataStore
         suspend fun markEducationDialogShown() {
             context.appPreferencesDataStore.edit { preferences ->
                 preferences[FIRST_TIME_DIALOG_SHOWN] = true
+            }
+        }
+
+        val hideBatteryOptReminder: Flow<Boolean> =
+            context.appPreferencesDataStore.data
+                .map { preferences ->
+                    preferences[HIDE_BATTERY_OPT_REMINDER] ?: false
+                }
+
+        suspend fun setHideBatteryOptReminder(hide: Boolean) {
+            context.appPreferencesDataStore.edit { preferences ->
+                preferences[HIDE_BATTERY_OPT_REMINDER] = hide
             }
         }
     }

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlert.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlert.kt
@@ -96,7 +96,7 @@ data object AddNewRemoteAlertScreen : Screen {
 
         data object OpenBatterySettings : Event()
 
-        data object HideBatteryOptReminder : Event()
+        data object HideBatteryOptimizationReminder : Event()
 
         data class UpdateAlertType(
             val alertType: AlertType,
@@ -203,7 +203,7 @@ class AddNewRemoteAlertPresenter
                     is AddNewRemoteAlertScreen.Event.UpdateThreshold -> {
                         threshold = event.value
                     }
-                    AddNewRemoteAlertScreen.Event.HideBatteryOptReminder -> {
+                    AddNewRemoteAlertScreen.Event.HideBatteryOptimizationReminder -> {
                         scope.launch {
                             appPreferencesDataStore.setHideBatteryOptReminder(true)
                         }
@@ -407,8 +407,8 @@ fun AddNewRemoteAlertUi(
                 onSettingsClick = {
                     state.eventSink(AddNewRemoteAlertScreen.Event.OpenBatterySettings)
                 },
-                onDontRemind = {
-                    state.eventSink(AddNewRemoteAlertScreen.Event.HideBatteryOptReminder)
+                onDontRemindAgain = {
+                    state.eventSink(AddNewRemoteAlertScreen.Event.HideBatteryOptimizationReminder)
                     state.eventSink(AddNewRemoteAlertScreen.Event.DismissBatteryOptimizationSheet)
                 },
                 onDismiss = {

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalert/BatteryOptimizationBottomSheet.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalert/BatteryOptimizationBottomSheet.kt
@@ -20,8 +20,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -38,7 +36,7 @@ import dev.hossain.remotenotify.theme.ComposeAppTheme
 fun BatteryOptimizationBottomSheet(
     sheetState: SheetState,
     onSettingsClick: () -> Unit,
-    onDontRemind: () -> Unit,
+    onDontRemindAgain: () -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -47,14 +45,14 @@ fun BatteryOptimizationBottomSheet(
         sheetState = sheetState,
         modifier = modifier,
     ) {
-        BatteryOptimizationUi(onSettingsClick = onSettingsClick, onDontRemind = onDontRemind)
+        BatteryOptimizationUi(onSettingsClick = onSettingsClick, onDontRemindAgain = onDontRemindAgain)
     }
 }
 
 @Composable
 private fun BatteryOptimizationUi(
     onSettingsClick: () -> Unit,
-    onDontRemind: () -> Unit,
+    onDontRemindAgain: () -> Unit,
 ) {
     Column(
         modifier =
@@ -116,7 +114,7 @@ private fun BatteryOptimizationUi(
             }
 
             TextButton(
-                onClick = onDontRemind,
+                onClick = onDontRemindAgain,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text("Don't remind me again")
@@ -133,7 +131,7 @@ private fun BatteryOptimizationUi(
 private fun PreviewBatteryOptimizationUi() {
     ComposeAppTheme {
         Surface {
-            BatteryOptimizationUi({}, {})
+            BatteryOptimizationUi(onSettingsClick = {}, onDontRemindAgain = {})
         }
     }
 }

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalert/BatteryOptimizationBottomSheet.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalert/BatteryOptimizationBottomSheet.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
@@ -37,6 +38,7 @@ import dev.hossain.remotenotify.theme.ComposeAppTheme
 fun BatteryOptimizationBottomSheet(
     sheetState: SheetState,
     onSettingsClick: () -> Unit,
+    onDontRemind: () -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -45,12 +47,15 @@ fun BatteryOptimizationBottomSheet(
         sheetState = sheetState,
         modifier = modifier,
     ) {
-        BatteryOptimizationUi(onSettingsClick)
+        BatteryOptimizationUi(onSettingsClick = onSettingsClick, onDontRemind = onDontRemind)
     }
 }
 
 @Composable
-private fun BatteryOptimizationUi(onSettingsClick: () -> Unit) {
+private fun BatteryOptimizationUi(
+    onSettingsClick: () -> Unit,
+    onDontRemind: () -> Unit,
+) {
     Column(
         modifier =
             Modifier
@@ -93,17 +98,29 @@ private fun BatteryOptimizationUi(onSettingsClick: () -> Unit) {
         }
 
         // Action Button
-        FilledTonalButton(
-            onClick = onSettingsClick,
+        Column(
+            verticalArrangement = Arrangement.spacedBy(8.dp),
             modifier = Modifier.fillMaxWidth(),
         ) {
-            Icon(
-                Icons.Default.Settings,
-                contentDescription = null,
-                modifier = Modifier.size(18.dp),
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text("Open Settings")
+            FilledTonalButton(
+                onClick = onSettingsClick,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(
+                    Icons.Default.Settings,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Open Settings")
+            }
+
+            TextButton(
+                onClick = onDontRemind,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text("Don't remind me again")
+            }
         }
 
         Spacer(modifier = Modifier.height(8.dp))
@@ -116,7 +133,7 @@ private fun BatteryOptimizationUi(onSettingsClick: () -> Unit) {
 private fun PreviewBatteryOptimizationUi() {
     ComposeAppTheme {
         Surface {
-            BatteryOptimizationUi {}
+            BatteryOptimizationUi({}, {})
         }
     }
 }

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalert/BatteryOptimizationBottomSheet.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalert/BatteryOptimizationBottomSheet.kt
@@ -97,7 +97,7 @@ private fun BatteryOptimizationUi(
 
         // Action Button
         Column(
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
             modifier = Modifier.fillMaxWidth(),
         ) {
             FilledTonalButton(


### PR DESCRIPTION
AI solution worked flawlessly from https://github.com/hossain-khan/android-remote-notify/issues/188#issuecomment-2691830604

Fixes #188


This pull request introduces a new feature to allow users to hide the battery optimization reminder in the app. The changes include updates to the `AppPreferencesDataStore` to store the preference, modifications to the `AddNewRemoteAlert` screen to handle the new preference, and updates to the `BatteryOptimizationBottomSheet` to provide an option for users to hide the reminder.

### New Feature: Hide Battery Optimization Reminder

* [`app/src/main/java/dev/hossain/remotenotify/data/AppPreferencesDataStore.kt`](diffhunk://#diff-167f937567870faa3c1d37b8cb1a4252bc460eefa5a0d5b939d48789d8f94a25R30): Added a new boolean preference key `HIDE_BATTERY_OPTIMIZATION_REMINDER` and corresponding methods to save and retrieve this preference. [[1]](diffhunk://#diff-167f937567870faa3c1d37b8cb1a4252bc460eefa5a0d5b939d48789d8f94a25R30) [[2]](diffhunk://#diff-167f937567870faa3c1d37b8cb1a4252bc460eefa5a0d5b939d48789d8f94a25R68-R79)

* `app/src/main/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlert.kt`: 
  - Imported `AppPreferencesDataStore` and added it as a dependency in the `AddNewRemoteAlertPresenter` class. [[1]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR60) [[2]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR117)
  - Added a new `hideBatteryOptReminder` state and updated the `AddNewRemoteAlertScreen.State` and `Event` classes to handle the new preference. [[1]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR82) [[2]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR99-R100) [[3]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR127-R128) [[4]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR145-R150) [[5]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR174) [[6]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR206-R210)
  - Updated the UI to conditionally show the battery optimization card based on the new preference. [[1]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fL372-R392) [[2]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR410-R413) [[3]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR478) [[4]](diffhunk://#diff-116094f0ff26b036f73733b7547d445ef3591fbfe2031b0decd366ceb05d3e6fR499)

* `app/src/main/java/dev/hossain/remotenotify/ui/addalert/BatteryOptimizationBottomSheet.kt`: 
  - Added a new button "Don't remind me again" to the `BatteryOptimizationUi` and updated the `BatteryOptimizationBottomSheet` to handle the new button click event. [[1]](diffhunk://#diff-053545a1043b8acade93c2ec85507b7467702efcd4d521b63999132f935e8d4eR21-L23) [[2]](diffhunk://#diff-053545a1043b8acade93c2ec85507b7467702efcd4d521b63999132f935e8d4eR39) [[3]](diffhunk://#diff-053545a1043b8acade93c2ec85507b7467702efcd4d521b63999132f935e8d4eL48-R56) [[4]](diffhunk://#diff-053545a1043b8acade93c2ec85507b7467702efcd4d521b63999132f935e8d4eR99-R102) [[5]](diffhunk://#diff-053545a1043b8acade93c2ec85507b7467702efcd4d521b63999132f935e8d4eR116-R123) [[6]](diffhunk://#diff-053545a1043b8acade93c2ec85507b7467702efcd4d521b63999132f935e8d4eL119-R134)