### PR TITLE
[FIXED] The interval value not persisted

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/WorkerCheckIntervalConfigUi.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/WorkerCheckIntervalConfigUi.kt
@@ -36,7 +36,11 @@ internal fun WorkerConfigCard(
     state: NotificationMediumListScreen.State,
     modifier: Modifier = Modifier,
 ) {
-    var intervalSliderValue by remember { mutableFloatStateOf(state.workerIntervalMinutes.toFloat()) }
+    // Update intervalSliderValue whenever state.workerIntervalMinutes changes
+    var intervalSliderValue by remember(state.workerIntervalMinutes) {
+        mutableFloatStateOf(state.workerIntervalMinutes.toFloat())
+    }
+
     val alertCheckIntervalRangeStart = 60f // 1 hour
     val alertCheckIntervalRangeEnd = 720f // 12 hours
 


### PR DESCRIPTION
After lot of back and forth and debugging I found the issue, AI didn't help.

Fixes #191

This pull request includes several changes to the `NotificationMediumListScreen.kt` and `WorkerCheckIntervalConfigUi.kt` files to improve the handling of state and flow in the application. The key changes include updating imports, modifying how state is collected from DataStore, and enhancing the debounce and filter logic for worker intervals.

### Improvements to state and flow handling:

* [`NotificationMediumListScreen.kt`](diffhunk://#diff-0246f0556076a11132ed5cb000a8a2652b46dc0b326c4376ff370b5c8a9f86c6L123-R126): Added `collectAsState` to directly collect worker interval state from DataStore preferences.
* [`NotificationMediumListScreen.kt`](diffhunk://#diff-0246f0556076a11132ed5cb000a8a2652b46dc0b326c4376ff370b5c8a9f86c6L177-R177): Added `filter` to the worker interval flow to ignore default values before collecting.

### Import updates:

* [`NotificationMediumListScreen.kt`](diffhunk://#diff-0246f0556076a11132ed5cb000a8a2652b46dc0b326c4376ff370b5c8a9f86c6R32-L34): Added `collectAsState` import and removed `produceState` import.
* [`NotificationMediumListScreen.kt`](diffhunk://#diff-0246f0556076a11132ed5cb000a8a2652b46dc0b326c4376ff370b5c8a9f86c6R66): Added `filter` import.

### State management enhancement:

* [`WorkerCheckIntervalConfigUi.kt`](diffhunk://#diff-079cb9d22c8b22976e11a092c821b5d8cbeeee3ff92207adef943aae1266a2f7L39-R43): Updated `intervalSliderValue` to be remembered whenever `state.workerIntervalMinutes` changes.