### PR TITLE
[FIXED] Class cash exception on launch when `SharedElementTransitionLayout` is used

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,7 +26,7 @@ android {
         targetSdk = 35
         versionCode = 12
         // 📣 Don't forget to update release notes! 🤓
-        versionName = "1.11"
+        versionName = "1.10.1"
 
         // Read key or other properties from local.properties
         val localProperties =

--- a/app/src/main/java/dev/hossain/remotenotify/MainActivity.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/MainActivity.kt
@@ -13,7 +13,6 @@ import com.slack.circuit.foundation.CircuitCompositionLocals
 import com.slack.circuit.foundation.NavigableCircuitContent
 import com.slack.circuit.foundation.rememberCircuitNavigator
 import com.slack.circuit.overlay.ContentWithOverlays
-import com.slack.circuit.sharedelements.SharedElementTransitionLayout
 import com.slack.circuitx.gesturenavigation.GestureNavigationDecorationFactory
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dev.hossain.remotenotify.di.ActivityKey
@@ -43,17 +42,16 @@ class MainActivity
                     // See https://slackhq.github.io/circuit/circuit-content/
                     CircuitCompositionLocals(circuit) {
                         // See https://slackhq.github.io/circuit/shared-elements/
-                        SharedElementTransitionLayout {
-                            ContentWithOverlays {
-                                NavigableCircuitContent(
-                                    navigator = navigator,
-                                    backStack = backStack,
-                                    decoratorFactory =
-                                        remember(navigator) {
-                                            GestureNavigationDecorationFactory(onBackInvoked = navigator::pop)
-                                        },
-                                )
-                            }
+
+                        ContentWithOverlays {
+                            NavigableCircuitContent(
+                                navigator = navigator,
+                                backStack = backStack,
+                                decoratorFactory =
+                                    remember(navigator) {
+                                        GestureNavigationDecorationFactory(onBackInvoked = navigator::pop)
+                                    },
+                            )
                         }
                     }
                 }

--- a/project-resources/google-play/release-notes.md
+++ b/project-resources/google-play/release-notes.md
@@ -1,6 +1,16 @@
 # What's New
 📝 Release notes 
 
+## Release v1.10.1
+- Initial 1.x release of 'Remote Notify'! 🎉
+- Monitor battery 🔋 and storage 💾 levels of your remote Android devices.
+- Set up custom alerts and receive notifications via Email, Twilio SMS, Telegram, and REST webhooks.
+- Added alert check log viewer with filtering to diagnose issues.
+- Minor bug fixes and UI/UX improvements.
+- Fixed alert check interval slider not persisting value.
+- Configured medium now shows preview of config value.
+- 💥 Fixed a crash on launch for some users.
+
 ## Release v1.10
 - Initial 1.x release of 'Remote Notify'! 🎉
 - Monitor battery 🔋 and storage 💾 levels of your remote Android devices.


### PR DESCRIPTION
Fixes #209