### PR TITLE
[ADDED] Test for app preferences

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/data/AppPreferencesDataStore.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/AppPreferencesDataStore.kt
@@ -30,6 +30,12 @@ class AppPreferencesDataStore
             private val HIDE_BATTERY_OPTIMIZATION_REMINDER = booleanPreferencesKey("hide_battery_optimization_reminder")
         }
 
+        suspend fun resetAll() {
+            context.appPreferencesDataStore.edit { preferences ->
+                preferences.clear()
+            }
+        }
+
         suspend fun saveWorkerInterval(intervalMinutes: Long) {
             context.appPreferencesDataStore.edit { preferences ->
                 preferences[WORKER_INTERVAL_KEY] = intervalMinutes

--- a/app/src/test/java/dev/hossain/remotenotify/data/AppPreferencesDataStoreTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/data/AppPreferencesDataStoreTest.kt
@@ -1,0 +1,163 @@
+package dev.hossain.remotenotify.data
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import dev.hossain.remotenotify.worker.DEFAULT_PERIODIC_INTERVAL_MINUTES
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class AppPreferencesDataStoreTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private val testScope = TestScope(testDispatcher + Job())
+    private lateinit var context: Context
+    private lateinit var appPreferencesDataStore: AppPreferencesDataStore
+    private val testDataStoreName = "test_app_preferences"
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+
+        // Clean up any existing test files
+        File(context.filesDir, "$testDataStoreName.preferences").delete()
+
+        // Create test instance
+        appPreferencesDataStore = AppPreferencesDataStore(context)
+    }
+
+    @After
+    fun tearDown() {
+        // Clean up the test DataStore file
+        File(context.filesDir, "$testDataStoreName.preferences").delete()
+    }
+
+    @Test
+    fun `workerIntervalFlow defaults to DEFAULT_PERIODIC_INTERVAL_MINUTES when not set`() =
+        runTest {
+            // When
+            val result = appPreferencesDataStore.workerIntervalFlow.first()
+
+            // Then
+            assertThat(result).isEqualTo(DEFAULT_PERIODIC_INTERVAL_MINUTES)
+        }
+
+    @Test
+    fun `lastReviewRequestFlow defaults to 0 when not set`() =
+        runTest {
+            appPreferencesDataStore.resetAll()
+
+            // When
+            val result = appPreferencesDataStore.lastReviewRequestFlow.first()
+
+            // Then
+            assertThat(result).isEqualTo(0)
+        }
+
+    @Test
+    fun `isFirstTimeDialogShown defaults to false when not set`() =
+        runTest {
+            // When
+            val result = appPreferencesDataStore.isFirstTimeDialogShown.first()
+
+            // Then
+            assertThat(result).isFalse()
+        }
+
+    @Test
+    fun `saveWorkerInterval updates interval value`() =
+        runTest {
+            // Given
+            val initialValue = appPreferencesDataStore.workerIntervalFlow.first()
+            assertThat(initialValue).isEqualTo(DEFAULT_PERIODIC_INTERVAL_MINUTES)
+
+            // When
+            val newInterval = 60L
+            appPreferencesDataStore.saveWorkerInterval(newInterval)
+
+            // Then
+            val updatedValue = appPreferencesDataStore.workerIntervalFlow.first()
+            assertThat(updatedValue).isEqualTo(newInterval)
+        }
+
+    @Test
+    fun `saveLastReviewRequestTime updates timestamp value`() =
+        runTest {
+            // Given
+            val initialValue = appPreferencesDataStore.lastReviewRequestFlow.first()
+            assertThat(initialValue).isEqualTo(0)
+
+            // When
+            val timestamp = System.currentTimeMillis()
+            appPreferencesDataStore.saveLastReviewRequestTime(timestamp)
+
+            // Then
+            val updatedValue = appPreferencesDataStore.lastReviewRequestFlow.first()
+            assertThat(updatedValue).isEqualTo(timestamp)
+        }
+
+    @Test
+    fun `saveFirstTimeDialogShown updates dialog shown status`() =
+        runTest {
+            // Given
+            val initialValue = appPreferencesDataStore.isFirstTimeDialogShown.first()
+            assertThat(initialValue).isFalse()
+
+            // When
+            appPreferencesDataStore.markEducationDialogShown()
+
+            // Then
+            val updatedValue = appPreferencesDataStore.isFirstTimeDialogShown.first()
+            assertThat(updatedValue).isTrue()
+        }
+
+    @Test
+    fun `saveWorkerInterval can update value multiple times`() =
+        runTest {
+            appPreferencesDataStore.resetAll()
+
+            // Initial state
+            assertThat(appPreferencesDataStore.workerIntervalFlow.first()).isEqualTo(DEFAULT_PERIODIC_INTERVAL_MINUTES)
+
+            // First update
+            appPreferencesDataStore.saveWorkerInterval(30L)
+            assertThat(appPreferencesDataStore.workerIntervalFlow.first()).isEqualTo(30L)
+
+            // Second update
+            appPreferencesDataStore.saveWorkerInterval(60L)
+            assertThat(appPreferencesDataStore.workerIntervalFlow.first()).isEqualTo(60L)
+
+            // Third update
+            appPreferencesDataStore.saveWorkerInterval(15L)
+            assertThat(appPreferencesDataStore.workerIntervalFlow.first()).isEqualTo(15L)
+        }
+
+    @Test
+    fun `values persist across DataStore instances`() =
+        runTest {
+            // Given
+            val timestamp = System.currentTimeMillis()
+            appPreferencesDataStore.saveWorkerInterval(45L)
+            appPreferencesDataStore.saveLastReviewRequestTime(timestamp)
+            appPreferencesDataStore.markEducationDialogShown()
+
+            // When - recreate the DataStore instance
+            val newInstance = AppPreferencesDataStore(context)
+
+            // Then
+            assertThat(newInstance.workerIntervalFlow.first()).isEqualTo(45L)
+            assertThat(newInstance.lastReviewRequestFlow.first()).isEqualTo(timestamp)
+            assertThat(newInstance.isFirstTimeDialogShown.first()).isTrue()
+        }
+}

--- a/app/src/test/java/dev/hossain/remotenotify/data/EmailConfigDataStoreTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/data/EmailConfigDataStoreTest.kt
@@ -50,7 +50,7 @@ class EmailConfigDataStoreTest {
     @After
     fun tearDown() {
         // Clean up the test DataStore file
-        File(context.filesDir, "$testDataStoreName.preferences_pb").delete()
+        File(context.filesDir, "$testDataStoreName.preferences").delete()
     }
 
     @Test

--- a/app/src/test/java/dev/hossain/remotenotify/data/TwilioConfigDataStoreTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/data/TwilioConfigDataStoreTest.kt
@@ -49,7 +49,7 @@ class TwilioConfigDataStoreTest {
     @After
     fun tearDown() {
         // Clean up the test DataStore file
-        File(context.filesDir, "$testDataStoreName.preferences_pb").delete()
+        File(context.filesDir, "$testDataStoreName.preferences").delete()
     }
 
     @Test

--- a/app/src/test/java/dev/hossain/remotenotify/data/WebhookConfigDataStoreTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/data/WebhookConfigDataStoreTest.kt
@@ -33,7 +33,7 @@ class WebhookConfigDataStoreTest {
         context = ApplicationProvider.getApplicationContext()
 
         // Clean up any existing test files
-        File(context.filesDir, "$testDataStoreName.preferences_pb").delete()
+        File(context.filesDir, "$testDataStoreName.preferences").delete()
 
         // Create a test-specific DataStore
         val testDataStore =
@@ -49,7 +49,7 @@ class WebhookConfigDataStoreTest {
     @After
     fun tearDown() {
         // Clean up the test DataStore file
-        File(context.filesDir, "$testDataStoreName.preferences_pb").delete()
+        File(context.filesDir, "$testDataStoreName.preferences").delete()
     }
 
     @Test


### PR DESCRIPTION
This pull request introduces a new method to reset all preferences in `AppPreferencesDataStore` and adds comprehensive unit tests for the `AppPreferencesDataStore` class. Additionally, it standardizes the file cleanup process across multiple test classes.

### New functionality:
* [`app/src/main/java/dev/hossain/remotenotify/data/AppPreferencesDataStore.kt`](diffhunk://#diff-167f937567870faa3c1d37b8cb1a4252bc460eefa5a0d5b939d48789d8f94a25R33-R38): Added a `resetAll` method to clear all preferences.

### Unit tests:
* [`app/src/test/java/dev/hossain/remotenotify/data/AppPreferencesDataStoreTest.kt`](diffhunk://#diff-fafc121259ef3a5750bf4f99a51cf01c36896531ad5750739dc83bd4ce0cb09fR1-R163): Added new unit tests to verify the functionality of `AppPreferencesDataStore`, including tests for default values, updating values, and persistence across instances.

### Standardization:
* [`app/src/test/java/dev/hossain/remotenotify/data/EmailConfigDataStoreTest.kt`](diffhunk://#diff-df937d1f04355601dfc7395eea8596ec269b7743aebba39a81fb39dbe430e482L53-R53): Updated the file cleanup process in the `tearDown` method to delete the correct preferences file.
* [`app/src/test/java/dev/hossain/remotenotify/data/TwilioConfigDataStoreTest.kt`](diffhunk://#diff-c51b6229db3ad1718bdf73ac96297c6fe33dfe5b4544a20e4c96affb1c7bfd83L52-R52): Updated the file cleanup process in the `tearDown` method to delete the correct preferences file.
* [`app/src/test/java/dev/hossain/remotenotify/data/WebhookConfigDataStoreTest.kt`](diffhunk://#diff-ac019d5252a608fd51c60c90f401e7f55470a696b3dec446c2a22a5d09666d1dL36-R36): Updated the file cleanup process in the `tearDown` method to delete the correct preferences file. [[1]](diffhunk://#diff-ac019d5252a608fd51c60c90f401e7f55470a696b3dec446c2a22a5d09666d1dL36-R36) [[2]](diffhunk://#diff-ac019d5252a608fd51c60c90f401e7f55470a696b3dec446c2a22a5d09666d1dL52-R52)