### PR TITLE
Realease unit test

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/data/TelegramConfigDataStore.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/TelegramConfigDataStore.kt
@@ -92,7 +92,7 @@ class TelegramConfigDataStore
             // Bot token format: 123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
             val isValidBotToken = botToken.matches(Regex("""\d+:[A-Za-z0-9_-]{35}"""))
             if (!isValidBotToken) {
-                Timber.e("Invalid bot token format")
+                Timber.w("Invalid bot token format")
                 errors[ValidationKeys.BOT_TOKEN] = "Invalid bot token format. Example format: 123456:ABCDEF1234ghIklzyx57W2v1u123ew11"
             }
 
@@ -101,7 +101,7 @@ class TelegramConfigDataStore
                 chatId.matches(Regex("""^-?\d+$""")) ||
                     (chatId.startsWith("@") && chatId.length > 1)
             if (!isValidChatId) {
-                Timber.e("Invalid chat ID format")
+                Timber.w("Invalid chat ID format")
                 errors[ValidationKeys.CHAT_ID] = "Invalid chat ID format. Chat ID should be numeric or @channelusername"
             }
 

--- a/app/src/test/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorkerTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorkerTest.kt
@@ -78,6 +78,7 @@ class ObserveDeviceHealthWorkerTest {
 
         // Mock Timber to prevent FirebaseCrashlytics errors
         val timber = mockk<Timber.Tree>(relaxed = true)
+        Timber.uprootAll()
         Timber.plant(timber)
 
         // Configure default behavior for notification sender

--- a/app/src/test/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorkerTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorkerTest.kt
@@ -24,6 +24,7 @@ import io.mockk.mockk
 import io.mockk.spyk
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.BeforeClass
@@ -31,6 +32,7 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import timber.log.Timber
 
 @RunWith(RobolectricTestRunner::class)
 class ObserveDeviceHealthWorkerTest {
@@ -74,6 +76,10 @@ class ObserveDeviceHealthWorkerTest {
         MockKAnnotations.init(this)
         context = ApplicationProvider.getApplicationContext()
 
+        // Mock Timber to prevent FirebaseCrashlytics errors
+        val timber = mockk<Timber.Tree>(relaxed = true)
+        Timber.plant(timber)
+
         // Configure default behavior for notification sender
         coEvery { notificationSender.hasValidConfig() } returns true
         every { notificationSender.notifierType } returns NotifierType.EMAIL
@@ -99,6 +105,12 @@ class ObserveDeviceHealthWorkerTest {
         // Create a spy for the worker and mock setProgress
         worker = spyk(worker)
         coEvery { worker.setProgress(any()) } just Runs
+    }
+
+    @After
+    fun tearDown() {
+        // Remove all trees to clean up after test
+        Timber.uprootAll()
     }
 
     @Test


### PR DESCRIPTION
This pull request includes changes to improve logging practices and enhance test setup and teardown procedures. The most important changes include modifying log levels, updating test imports, and managing logging trees in tests.

Logging improvements:

* [`app/src/main/java/dev/hossain/remotenotify/data/TelegramConfigDataStore.kt`](diffhunk://#diff-e14ec39286872cefac09b71989cf8e0c7e4570e28de4f33925b639ffc21ad3d7L95-R95): Changed log level from `Timber.e` to `Timber.w` for invalid bot token and chat ID format messages. [[1]](diffhunk://#diff-e14ec39286872cefac09b71989cf8e0c7e4570e28de4f33925b639ffc21ad3d7L95-R95) [[2]](diffhunk://#diff-e14ec39286872cefac09b71989cf8e0c7e4570e28de4f33925b639ffc21ad3d7L104-R104)

Test enhancements:

* [`app/src/test/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorkerTest.kt`](diffhunk://#diff-5d5d7d8a65dd73d19d5102cefeb000021b41c5edf3bc42c7eea7338536a2236aR27-R35): Added `Timber` import and mocked `Timber.Tree` to prevent errors during tests. [[1]](diffhunk://#diff-5d5d7d8a65dd73d19d5102cefeb000021b41c5edf3bc42c7eea7338536a2236aR27-R35) [[2]](diffhunk://#diff-5d5d7d8a65dd73d19d5102cefeb000021b41c5edf3bc42c7eea7338536a2236aR79-R83)
* [`app/src/test/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorkerTest.kt`](diffhunk://#diff-5d5d7d8a65dd73d19d5102cefeb000021b41c5edf3bc42c7eea7338536a2236aR111-R116): Implemented `tearDown` method to remove all `Timber` trees after tests to ensure a clean state.