### PR TITLE
[FIXED] Top padding on config list screen

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumconfig/SlackWebhookConfigInputUi.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumconfig/SlackWebhookConfigInputUi.kt
@@ -2,15 +2,25 @@ package dev.hossain.remotenotify.ui.alertmediumconfig
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalUriHandler
@@ -71,6 +81,35 @@ internal fun SlackWebhookConfigInputUi(
                 },
             color = MaterialTheme.colorScheme.onSurface,
         )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Add info card about Slack paid plan requirement
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors =
+                CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.7f),
+                ),
+        ) {
+            Row(
+                modifier = Modifier.padding(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Info,
+                    contentDescription = "Information",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(24.dp),
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(
+                    text = "Note: Workflows are only available on paid Slack plans.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer,
+                )
+            }
+        }
 
         Spacer(modifier = Modifier.height(16.dp))
 

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/NotificationMediumListScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertmediumlist/NotificationMediumListScreen.kt
@@ -251,7 +251,7 @@ fun NotificationMediumListUi(
     ) { padding ->
         LazyColumn(
             modifier = Modifier.padding(padding),
-            contentPadding = PaddingValues(16.dp),
+            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 0.dp, bottom = 8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             // Add a focus requester to the first item


### PR DESCRIPTION
This pull request includes changes to enhance the UI components and improve the user experience in the `SlackWebhookConfigInputUi` and `NotificationMediumListUi` screens. The most important changes include the addition of a new info card about Slack's paid plan requirement and adjustments to padding values for better layout consistency.

UI Enhancements:

* [`SlackWebhookConfigInputUi.kt`](diffhunk://#diff-f5332fc5a5bdb677e442de863566200d89b4f8ddeabe914372220c7a2318fac8R85-R113): Added a new info card to inform users about the Slack paid plan requirement. This includes the use of `Card`, `Row`, and `Icon` components for better visual presentation.
* [`SlackWebhookConfigInputUi.kt`](diffhunk://#diff-f5332fc5a5bdb677e442de863566200d89b4f8ddeabe914372220c7a2318fac8R5-R23): Imported additional layout and material components to support the new info card feature.

Layout Improvements:

* [`NotificationMediumListScreen.kt`](diffhunk://#diff-0246f0556076a11132ed5cb000a8a2652b46dc0b326c4376ff370b5c8a9f86c6L254-R254): Adjusted the padding values in the `NotificationMediumListUi` to provide a more consistent layout and better spacing.