### PR TITLE
[FIXED] Notification data with current device state value being not sent/used.

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertchecklog/AlertCheckLogViewerScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertchecklog/AlertCheckLogViewerScreen.kt
@@ -795,7 +795,7 @@ private fun LogItemCard(
                         Text(
                             text =
                                 if (log.isAlertSent) {
-                                    "Alert triggered & sent via ${log.notifierType?.name?.toTitleCase() ?: "N/A"}"
+                                    "Alert triggered & sent via ${log.notifierType?.displayName ?: "N/A"}"
                                 } else {
                                     "Alert not triggered"
                                 },

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertchecklog/AlertCheckLogViewerScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertchecklog/AlertCheckLogViewerScreen.kt
@@ -101,7 +101,6 @@ import dev.hossain.remotenotify.theme.ComposeAppTheme
 import dev.hossain.remotenotify.utils.formatDateTime
 import dev.hossain.remotenotify.utils.formatDuration
 import dev.hossain.remotenotify.utils.formatTimeElapsed
-import dev.hossain.remotenotify.utils.toTitleCase
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import java.text.SimpleDateFormat

--- a/app/src/test/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorkerTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorkerTest.kt
@@ -185,8 +185,9 @@ class ObserveDeviceHealthWorkerTest {
             val result = worker.doWork()
 
             // Then
+            val triggeredAlert = batteryAlert.copy(batteryPercentage = 15)
             assertEquals(ListenableWorker.Result.success(), result)
-            coVerify { notificationSender.sendNotification(batteryAlert) }
+            coVerify { notificationSender.sendNotification(triggeredAlert) }
             coVerify { repository.insertAlertCheckLog(1L, AlertType.BATTERY, 15, true, NotifierType.EMAIL) }
         }
 
@@ -234,8 +235,9 @@ class ObserveDeviceHealthWorkerTest {
             val result = worker.doWork()
 
             // Then
+            val triggeredAlert = storageAlert.copy(storageMinSpaceGb = 8)
             assertEquals(ListenableWorker.Result.success(), result)
-            coVerify { notificationSender.sendNotification(storageAlert) }
+            coVerify { notificationSender.sendNotification(triggeredAlert) }
             coVerify { repository.insertAlertCheckLog(2L, AlertType.STORAGE, 8, true, NotifierType.EMAIL) }
         }
 
@@ -310,8 +312,9 @@ class ObserveDeviceHealthWorkerTest {
             val result = worker.doWork()
 
             // Then
+            val triggeredAlert = batteryAlert.copy(batteryPercentage = 15)
             assertEquals(ListenableWorker.Result.success(), result)
-            coVerify { notificationSender.sendNotification(batteryAlert) }
+            coVerify { notificationSender.sendNotification(triggeredAlert) }
             coVerify { repository.insertAlertCheckLog(1L, AlertType.BATTERY, 15, true, NotifierType.EMAIL) }
         }
 


### PR DESCRIPTION
Fixes #241

This pull request includes changes to improve the naming consistency and functionality of the `ObserveDeviceHealthWorker` class and its related test cases. The changes primarily involve renaming variables for better clarity and updating the notification logic to include the current state value in the alerts.

### Naming Consistency and Clarity:

* [`app/src/main/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorker.kt`](diffhunk://#diff-5ee689a1381aac1d7479b5b8c7766435e0973569eb8f48394bbec5b2a8c2d4a2L47-R52): Renamed `alerts` to `userConfiguredAlerts` to better reflect their purpose and updated all related references accordingly. [[1]](diffhunk://#diff-5ee689a1381aac1d7479b5b8c7766435e0973569eb8f48394bbec5b2a8c2d4a2L47-R52) [[2]](diffhunk://#diff-5ee689a1381aac1d7479b5b8c7766435e0973569eb8f48394bbec5b2a8c2d4a2L64-R64) [[3]](diffhunk://#diff-5ee689a1381aac1d7479b5b8c7766435e0973569eb8f48394bbec5b2a8c2d4a2L78-R90) [[4]](diffhunk://#diff-5ee689a1381aac1d7479b5b8c7766435e0973569eb8f48394bbec5b2a8c2d4a2L118-R127)

### Notification Logic Update:

* [`app/src/main/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorker.kt`](diffhunk://#diff-5ee689a1381aac1d7479b5b8c7766435e0973569eb8f48394bbec5b2a8c2d4a2R147-R164): Updated the notification logic to include the current state value in the alerts before sending notifications. This ensures that the notifications reflect the most recent device state.

### Test Case Adjustments:

* [`app/src/test/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorkerTest.kt`](diffhunk://#diff-5d5d7d8a65dd73d19d5102cefeb000021b41c5edf3bc42c7eea7338536a2236aR188-R190): Adjusted test cases to verify that the updated alerts with current state values are being sent in the notifications. [[1]](diffhunk://#diff-5d5d7d8a65dd73d19d5102cefeb000021b41c5edf3bc42c7eea7338536a2236aR188-R190) [[2]](diffhunk://#diff-5d5d7d8a65dd73d19d5102cefeb000021b41c5edf3bc42c7eea7338536a2236aR238-R240) [[3]](diffhunk://#diff-5d5d7d8a65dd73d19d5102cefeb000021b41c5edf3bc42c7eea7338536a2236aR315-R317)

### Minor Cleanup:

* [`app/src/main/java/dev/hossain/remotenotify/ui/alertchecklog/AlertCheckLogViewerScreen.kt`](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceL104): Removed unused import `dev.hossain.remotenotify.utils.toTitleCase` and replaced the usage of `toTitleCase` with `displayName`. [[1]](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceL104) [[2]](diffhunk://#diff-c9901ebae0410fae22b6cadffa72e67d1de45dfa765e59228a6df1822f62cbceL798-R797)
* [`app/src/main/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorker.kt`](diffhunk://#diff-5ee689a1381aac1d7479b5b8c7766435e0973569eb8f48394bbec5b2a8c2d4a2L19): Removed unused import `kotlin.text.toLong`.