### PR TITLE
The following commit message describes the changes I've made:

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -216,6 +216,8 @@ dependencies {
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.androidx.test.core.ktx)
     testImplementation(libs.androidx.work.testing)
+    testImplementation("app.cash.molecule:molecule-runtime:2.1.0")
+    testImplementation("app.cash.turbine:turbine:1.2.0")
     testImplementation(libs.google.truth)
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/app/src/test/java/dev/hossain/remotenotify/ui/about/AboutAppPresenterTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/ui/about/AboutAppPresenterTest.kt
@@ -1,0 +1,138 @@
+package dev.hossain.remotenotify.ui.about
+
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.test.junit4.createComposeRule
+import app.cash.molecule.RecompositionClock
+import app.cash.molecule.moleculeFlow
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import dev.hossain.remotenotify.BuildConfig
+import dev.hossain.remotenotify.analytics.Analytics
+import dev.hossain.remotenotify.platform.AppVersionProvider
+import dev.hossain.remotenotify.platform.BuildInfo
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import kotlin.time.ExperimentalTime
+
+/**
+ * Tests for [AboutAppPresenter].
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTime::class)
+class AboutAppPresenterTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val navigator: Navigator = mockk(relaxed = true)
+    private val analytics: Analytics = mockk(relaxed = true)
+    private val appVersionProvider: AppVersionProvider = mockk()
+
+    @Before
+    fun setUp() {
+        // Mock the app version provider to return a specific version for testing
+        coEvery { appVersionProvider.getAppVersion() } returns "v${BuildConfig.VERSION_NAME} (${BuildInfo.GIT_SHA})"
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(LocalUriHandler::class)
+    }
+
+    @Test
+    fun `initial state contains app version and showEducationSheet is false`() = runTest {
+        val expectedAppVersion = "v${BuildConfig.VERSION_NAME} (${BuildInfo.GIT_SHA})"
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            AboutAppPresenter(navigator = navigator, analytics = analytics, appVersionProvider = appVersionProvider)
+        }.test {
+            val state = awaitItem()
+            assertThat(state.appVersion).isEqualTo(expectedAppVersion)
+            assertThat(state.showEducationSheet).isFalse()
+            // Verify that getAppVersion was called
+            coVerify { appVersionProvider.getAppVersion() }
+        }
+    }
+
+    @Test
+    fun `event GoBack invokes navigator pop`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            AboutAppPresenter(navigator = navigator, analytics = analytics, appVersionProvider = appVersionProvider)
+        }.test {
+            val state = awaitItem()
+            state.eventSink(AboutAppScreenEvent.GoBack)
+            coVerify { navigator.pop() }
+        }
+    }
+
+    @Test
+    fun `event OpenGitHubProject opens project url via UriHandler`() = runTest {
+        val uriHandler = mockk<androidx.compose.ui.platform.UriHandler>(relaxed = true)
+        mockkStatic(LocalUriHandler::class)
+        every { LocalUriHandler.current } returns uriHandler
+
+        val expectedUrl = "https://github.com/hossain-khan/android-remote-notify"
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            AboutAppPresenter(navigator = navigator, analytics = analytics, appVersionProvider = appVersionProvider)
+        }.test {
+            val state = awaitItem()
+            state.eventSink(AboutAppScreenEvent.OpenGitHubProject)
+            coVerify { uriHandler.openUri(expectedUrl) }
+        }
+    }
+
+    @Test
+    fun `event OpenLearnMoreSheet sets showEducationSheet to true and logs analytics`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            AboutAppPresenter(navigator = navigator, analytics = analytics, appVersionProvider = appVersionProvider)
+        }.test {
+            val initialState = awaitItem()
+            assertThat(initialState.showEducationSheet).isFalse()
+
+            initialState.eventSink(AboutAppScreenEvent.OpenLearnMoreSheet)
+
+            val updatedState = awaitItem()
+            assertThat(updatedState.showEducationSheet).isTrue()
+            coVerify { analytics.logViewTutorial(isComplete = false) }
+        }
+    }
+
+    @Test
+    fun `event DismissLearnMoreSheet sets showEducationSheet to false and logs analytics`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            AboutAppPresenter(navigator = navigator, analytics = analytics, appVersionProvider = appVersionProvider)
+        }.test {
+            val initialState = awaitItem()
+            // First, open the sheet to ensure it's in the correct state for dismissal
+            initialState.eventSink(AboutAppScreenEvent.OpenLearnMoreSheet)
+            val stateAfterOpen = awaitItem()
+            assertThat(stateAfterOpen.showEducationSheet).isTrue() // Sanity check
+
+            // Now, dismiss the sheet
+            stateAfterOpen.eventSink(AboutAppScreenEvent.DismissLearnMoreSheet)
+
+            val finalState = awaitItem()
+            assertThat(finalState.showEducationSheet).isFalse()
+            coVerify { analytics.logViewTutorial(isComplete = true) }
+        }
+    }
+
+    @Test
+    fun `impression effect logs screen view`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            AboutAppPresenter(navigator = navigator, analytics = analytics, appVersionProvider = appVersionProvider)
+        }.test {
+            awaitItem() // Trigger LaunchedImpressionEffect by collecting the first item
+            coVerify { analytics.logScreenView(AboutAppScreen::class) }
+        }
+    }
+}

--- a/app/src/test/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlertPresenterTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlertPresenterTest.kt
@@ -1,0 +1,433 @@
+package dev.hossain.remotenotify.ui.addalert
+
+import android.app.Application
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.PowerManager
+import android.provider.Settings
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import app.cash.molecule.RecompositionClock
+import app.cash.molecule.moleculeFlow
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import dev.hossain.remotenotify.R
+import dev.hossain.remotenotify.analytics.Analytics
+import dev.hossain.remotenotify.data.AppPreferencesDataStore
+import dev.hossain.remotenotify.data.RemoteAlert
+import dev.hossain.remotenotify.data.RemoteAlertRepository
+import dev.hossain.remotenotify.model.AlertType
+import dev.hossain.remotenotify.platform.BatteryOptimizationHelper
+import dev.hossain.remotenotify.platform.StorageMonitor
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.shadows.ShadowApplication
+
+/**
+ * Tests for [AddNewRemoteAlertPresenter].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class AddNewRemoteAlertPresenterTest {
+    private lateinit var navigator: Navigator
+    private lateinit var remoteAlertRepository: RemoteAlertRepository
+    private lateinit var storageMonitor: StorageMonitor
+    private lateinit var appPreferencesDataStore: AppPreferencesDataStore
+    private lateinit var analytics: Analytics
+    private lateinit var mockContext: Application
+    private lateinit var mockPowerManager: PowerManager
+
+    private lateinit var lifecycleOwner: LifecycleOwner
+    private lateinit var lifecycleRegistry: LifecycleRegistry
+
+
+    @Before
+    fun setUp() {
+        navigator = mockk(relaxed = true)
+        remoteAlertRepository = mockk(relaxed = true)
+        storageMonitor = mockk()
+        appPreferencesDataStore = mockk(relaxed = true) // relaxed for setHideBatteryOptReminder
+        analytics = mockk(relaxed = true)
+        mockContext = mockk<Application>(relaxed = true)
+        mockPowerManager = mockk(relaxed = true)
+
+        // Mock static LocalContext.current to return our mockContext
+        // This is needed because the presenter uses LocalContext.current
+        mockkStatic(LocalContext::class)
+        every { LocalContext.current } returns mockContext
+
+        // Mock Android's Settings class for intent actions
+        mockkStatic(Settings::class)
+        // Mock application package name for ACTION_APPLICATION_DETAILS_SETTINGS
+        every { mockContext.packageName } returns "dev.hossain.remotenotify"
+        every { mockContext.applicationContext } returns mockContext
+
+
+        // Mock BatteryOptimizationHelper
+        mockkStatic(BatteryOptimizationHelper::class)
+
+        // Mock PowerManager service
+        every { mockContext.getSystemService(Context.POWER_SERVICE) } returns mockPowerManager
+
+        // Default mock for appPreferencesDataStore.hideBatteryOptReminder()
+        coEvery { appPreferencesDataStore.hideBatteryOptReminder() } returns flowOf(false)
+
+        // Setup lifecycle for DisposableEffect testing
+        lifecycleOwner = mockk()
+        lifecycleRegistry = LifecycleRegistry(lifecycleOwner)
+        every { lifecycleOwner.lifecycle } returns lifecycleRegistry
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll() // Unmock all static and regular mocks
+    }
+
+    private fun createPresenter(testLifecycleOwner: LifecycleOwner = lifecycleOwner): @Composable () -> AddNewRemoteAlertState {
+        return {
+            AddNewRemoteAlertPresenter(
+                navigator = navigator,
+                repository = remoteAlertRepository,
+                storageMonitor = storageMonitor,
+                appPreferences = appPreferencesDataStore,
+                analytics = analytics,
+                lifecycleOwner = testLifecycleOwner
+            )
+        }
+    }
+
+    @Test
+    fun `initial state is correctly set when battery is NOT optimized`() = runTest {
+        val availableStorageGb = 25
+        coEvery { storageMonitor.getAvailableStorageInGB() } returns availableStorageGb
+        coEvery { appPreferencesDataStore.hideBatteryOptReminder() } returns flowOf(false)
+        every { BatteryOptimizationHelper.isIgnoringBatteryOptimizations(mockContext) } returns false
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().invoke()
+        }.test {
+            val state = awaitItem()
+            assertThat(state.showBatteryOptSheet).isFalse()
+            assertThat(state.isBatteryOptimized).isFalse()
+            assertThat(state.selectedAlertType).isEqualTo(AlertType.BATTERY)
+            assertThat(state.threshold).isEqualTo(10) // Default for battery
+            assertThat(state.availableStorage).isEqualTo(availableStorageGb)
+            assertThat(state.storageSliderMax).isEqualTo(availableStorageGb - 1)
+            assertThat(state.hideBatteryOptReminder).isFalse()
+
+            coVerify { storageMonitor.getAvailableStorageInGB() }
+            coVerify { appPreferencesDataStore.hideBatteryOptReminder() }
+            verify { BatteryOptimizationHelper.isIgnoringBatteryOptimizations(mockContext) }
+        }
+    }
+
+    @Test
+    fun `initial state is correctly set when battery IS optimized`() = runTest {
+        val availableStorageGb = 30
+        coEvery { storageMonitor.getAvailableStorageInGB() } returns availableStorageGb
+        coEvery { appPreferencesDataStore.hideBatteryOptReminder() } returns flowOf(true) // Different value
+        every { BatteryOptimizationHelper.isIgnoringBatteryOptimizations(mockContext) } returns true
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().invoke()
+        }.test {
+            val state = awaitItem()
+            assertThat(state.showBatteryOptSheet).isFalse()
+            assertThat(state.isBatteryOptimized).isTrue()
+            assertThat(state.selectedAlertType).isEqualTo(AlertType.BATTERY)
+            assertThat(state.threshold).isEqualTo(10)
+            assertThat(state.availableStorage).isEqualTo(availableStorageGb)
+            assertThat(state.storageSliderMax).isEqualTo(availableStorageGb - 1)
+            assertThat(state.hideBatteryOptReminder).isTrue()
+        }
+    }
+
+    @Test
+    fun `event SaveNotification for BatteryAlert saves alert, logs analytics, and navigates back`() = runTest {
+        val batteryAlert = RemoteAlert.BatteryAlert(conditionId = "battery_low", threshold = 15, isEnabled = true)
+        coEvery { storageMonitor.getAvailableStorageInGB() } returns 100 // Needs to be mocked for initial state
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().invoke()
+        }.test {
+            val state = awaitItem() // Consume initial state
+
+            state.eventSink(AddNewRemoteAlertScreenEvent.SaveNotification(batteryAlert))
+
+            coVerify { analytics.logAlertAdded(batteryAlert.type, batteryAlert.threshold) }
+            coVerify { remoteAlertRepository.saveRemoteAlert(batteryAlert) }
+            coVerify { navigator.pop() }
+        }
+    }
+
+    @Test
+    fun `event SaveNotification for StorageAlert saves alert, logs analytics, and navigates back`() = runTest {
+        val storageAlert = RemoteAlert.StorageAlert(conditionId = "storage_low", threshold = 5, isEnabled = true)
+        coEvery { storageMonitor.getAvailableStorageInGB() } returns 100
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().invoke()
+        }.test {
+            val state = awaitItem()
+
+            state.eventSink(AddNewRemoteAlertScreenEvent.SaveNotification(storageAlert))
+
+            coVerify { analytics.logAlertAdded(storageAlert.type, storageAlert.threshold) }
+            coVerify { remoteAlertRepository.saveRemoteAlert(storageAlert) }
+            coVerify { navigator.pop() }
+        }
+    }
+
+    @Test
+    fun `event NavigateBack invokes navigator pop`() = runTest {
+        coEvery { storageMonitor.getAvailableStorageInGB() } returns 100
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().invoke()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(AddNewRemoteAlertScreenEvent.NavigateBack)
+            coVerify { navigator.pop() }
+        }
+    }
+
+    @Test
+    fun `event ShowBatteryOptimizationSheet updates state and logs analytics`() = runTest {
+        coEvery { storageMonitor.getAvailableStorageInGB() } returns 100
+        every { BatteryOptimizationHelper.isIgnoringBatteryOptimizations(mockContext) } returns false // Ensure sheet can be shown
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().invoke()
+        }.test {
+            val initialState = awaitItem()
+            assertThat(initialState.showBatteryOptSheet).isFalse()
+
+            initialState.eventSink(AddNewRemoteAlertScreenEvent.ShowBatteryOptimizationSheet)
+
+            val updatedState = awaitItem()
+            assertThat(updatedState.showBatteryOptSheet).isTrue()
+            coVerify { analytics.logOptimizeBatteryInfoShown() }
+        }
+    }
+
+    @Test
+    fun `event DismissBatteryOptimizationSheet updates state`() = runTest {
+        coEvery { storageMonitor.getAvailableStorageInGB() } returns 100
+        every { BatteryOptimizationHelper.isIgnoringBatteryOptimizations(mockContext) } returns false
+
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().invoke()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(AddNewRemoteAlertScreenEvent.ShowBatteryOptimizationSheet) // Show first
+            val stateAfterShow = awaitItem()
+            assertThat(stateAfterShow.showBatteryOptSheet).isTrue()
+
+            stateAfterShow.eventSink(AddNewRemoteAlertScreenEvent.DismissBatteryOptimizationSheet)
+            val stateAfterDismiss = awaitItem()
+            assertThat(stateAfterDismiss.showBatteryOptSheet).isFalse()
+        }
+    }
+
+    @Test
+    fun `event OpenBatterySettings logs analytics, updates state, and starts activity`() = runTest {
+        coEvery { storageMonitor.getAvailableStorageInGB() } returns 100
+        every { BatteryOptimizationHelper.isIgnoringBatteryOptimizations(mockContext) } returns false
+
+        val intentSlot = slot<Intent>()
+        every { mockContext.startActivity(capture(intentSlot)) } just Runs // Needed for void functions
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().invoke()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(AddNewRemoteAlertScreenEvent.ShowBatteryOptimizationSheet) // Show first
+            awaitItem() // consume state update
+
+            state.eventSink(AddNewRemoteAlertScreenEvent.OpenBatterySettings)
+
+            val updatedState = awaitItem()
+            assertThat(updatedState.showBatteryOptSheet).isFalse()
+
+            coVerify { analytics.logOptimizeBatteryGoToSettings() }
+            verify { mockContext.startActivity(any()) } // any() because intent creation is complex
+            assertThat(intentSlot.captured.action).isEqualTo(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+            assertThat(intentSlot.captured.data).isEqualTo(Uri.fromParts("package", mockContext.packageName, null))
+        }
+    }
+
+    @Test
+    fun `event UpdateAlertType to STORAGE adjusts threshold if current threshold is higher than max storage`() = runTest {
+        val initialAvailableStorage = 8 // Results in storageSliderMax = 7
+        coEvery { storageMonitor.getAvailableStorageInGB() } returns initialAvailableStorage
+        every { BatteryOptimizationHelper.isIgnoringBatteryOptimizations(mockContext) } returns true
+
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().invoke()
+        }.test {
+            val initialState = awaitItem()
+            assertThat(initialState.selectedAlertType).isEqualTo(AlertType.BATTERY)
+            // Initial threshold for BATTERY is 10, which is > initialAvailableStorage - 1 (7)
+            assertThat(initialState.threshold).isEqualTo(10)
+
+            initialState.eventSink(AddNewRemoteAlertScreenEvent.UpdateAlertType(AlertType.STORAGE))
+
+            val finalState = awaitItem()
+            assertThat(finalState.selectedAlertType).isEqualTo(AlertType.STORAGE)
+            // Threshold should be adjusted to max available for storage (initialAvailableStorage - 1)
+            assertThat(finalState.threshold).isEqualTo(initialAvailableStorage - 1)
+        }
+    }
+
+    @Test
+    fun `event UpdateAlertType to STORAGE keeps threshold if current threshold is within max storage`() = runTest {
+        val initialAvailableStorage = 20 // Results in storageSliderMax = 19
+        val initialThreshold = 15
+        coEvery { storageMonitor.getAvailableStorageInGB() } returns initialAvailableStorage
+        every { BatteryOptimizationHelper.isIgnoringBatteryOptimizations(mockContext) } returns true
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().invoke()
+        }.test {
+            var state = awaitItem()
+            // Set initial threshold for BATTERY to be within the new storage max
+            state.eventSink(AddNewRemoteAlertScreenEvent.UpdateThreshold(initialThreshold))
+            state = awaitItem()
+            assertThat(state.threshold).isEqualTo(initialThreshold)
+
+            state.eventSink(AddNewRemoteAlertScreenEvent.UpdateAlertType(AlertType.STORAGE))
+
+            val finalState = awaitItem()
+            assertThat(finalState.selectedAlertType).isEqualTo(AlertType.STORAGE)
+            assertThat(finalState.threshold).isEqualTo(initialThreshold) // Should remain initialThreshold
+        }
+    }
+
+
+    @Test
+    fun `event UpdateThreshold updates threshold state`() = runTest {
+        coEvery { storageMonitor.getAvailableStorageInGB() } returns 100
+        val newThreshold = 25
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().invoke()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(AddNewRemoteAlertScreenEvent.UpdateThreshold(newThreshold))
+
+            val updatedState = awaitItem()
+            assertThat(updatedState.threshold).isEqualTo(newThreshold)
+        }
+    }
+
+    @Test
+    fun `event HideBatteryOptimizationReminder logs analytics and updates datastore`() = runTest {
+        coEvery { storageMonitor.getAvailableStorageInGB() } returns 100
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().invoke()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(AddNewRemoteAlertScreenEvent.HideBatteryOptimizationReminder)
+
+            // awaitItem() // Recomposition might happen
+            val finalState = expectMostRecentItem()
+
+
+            coVerify { analytics.logOptimizeBatteryIgnore() }
+            coVerify { appPreferencesDataStore.setHideBatteryOptReminder(true) }
+            // Also verify the sheet is dismissed if it was shown due to this action (though not directly specified, good practice)
+            assertThat(finalState.showBatteryOptSheet).isFalse()
+        }
+    }
+
+    @Test
+    fun `impression effect logs screen view`() = runTest {
+        coEvery { storageMonitor.getAvailableStorageInGB() } returns 100
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().invoke()
+        }.test {
+            awaitItem() // Trigger LaunchedEffect for impression
+            coVerify { analytics.logScreenView(AddNewRemoteAlertScreen::class) }
+        }
+    }
+
+    @Test
+    fun `hideBatteryOptReminder state updates when datastore flow emits new value`() = runTest {
+        val hideReminderFlow = MutableSharedFlow<Boolean>()
+        coEvery { appPreferencesDataStore.hideBatteryOptReminder() } returns hideReminderFlow
+        coEvery { storageMonitor.getAvailableStorageInGB() } returns 100
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().invoke()
+        }.test {
+            hideReminderFlow.emit(false) // Initial emission
+            val initialState = awaitItem()
+            assertThat(initialState.hideBatteryOptReminder).isFalse()
+
+            hideReminderFlow.emit(true) // New emission
+            val updatedState = awaitItem()
+            assertThat(updatedState.hideBatteryOptReminder).isTrue()
+        }
+    }
+
+    @Test
+    fun `isBatteryOptimized state updates on lifecycle RESUME if helper returns different value`() = runTest {
+        coEvery { storageMonitor.getAvailableStorageInGB() } returns 100
+        // Initial state: not optimized
+        every { BatteryOptimizationHelper.isIgnoringBatteryOptimizations(mockContext) } returns false
+
+        // Custom lifecycle owner for this test
+        val testLifecycleOwner = mockk<LifecycleOwner>()
+        val testLifecycleRegistry = LifecycleRegistry(testLifecycleOwner)
+        every { testLifecycleOwner.lifecycle } returns testLifecycleRegistry
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter(testLifecycleOwner).invoke()
+        }.test {
+            // Initial state
+            testLifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+            testLifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
+            testLifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+            val initialState = awaitItem()
+            assertThat(initialState.isBatteryOptimized).isFalse()
+            verify(exactly = 1) { BatteryOptimizationHelper.isIgnoringBatteryOptimizations(mockContext) }
+
+
+            // Simulate app returning to foreground (ON_RESUME) and now battery is optimized
+            every { BatteryOptimizationHelper.isIgnoringBatteryOptimizations(mockContext) } returns true
+            testLifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE) // Must pause before resume
+            testLifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+
+            val updatedState = awaitItem() // This should be the state after ON_RESUME
+            assertThat(updatedState.isBatteryOptimized).isTrue()
+            // Check if helper was called again on resume
+            verify(exactly = 2) { BatteryOptimizationHelper.isIgnoringBatteryOptimizations(mockContext) }
+
+            testLifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+            testLifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        }
+    }
+}

--- a/app/src/test/java/dev/hossain/remotenotify/ui/alertchecklog/AlertCheckLogViewerPresenterTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/ui/alertchecklog/AlertCheckLogViewerPresenterTest.kt
@@ -1,0 +1,335 @@
+package dev.hossain.remotenotify.ui.alertchecklog
+
+import app.cash.molecule.RecompositionClock
+import app.cash.molecule.moleculeFlow
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import dev.hossain.remotenotify.analytics.Analytics
+import dev.hossain.remotenotify.data.AppPreferencesDataStore
+import dev.hossain.remotenotify.data.RemoteAlertRepository
+import dev.hossain.remotenotify.model.AlertCheckLog
+import dev.hossain.remotenotify.model.AlertType
+import dev.hossain.remotenotify.model.NotifierType
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.Calendar
+import java.util.concurrent.TimeUnit
+
+/**
+ * Tests for [AlertCheckLogViewerPresenter].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AlertCheckLogViewerPresenterTest {
+
+    private lateinit var navigator: Navigator
+    private lateinit var appPreferencesDataStore: AppPreferencesDataStore
+    private lateinit var remoteAlertRepository: RemoteAlertRepository
+    private lateinit var analytics: Analytics
+
+    // Test data timestamps
+    private val now = System.currentTimeMillis()
+    private val timeT0 = now
+    private val timeT1 = now - TimeUnit.HOURS.toMillis(1)
+    private val timeT2 = now - TimeUnit.HOURS.toMillis(2)
+    private val timeT3 = now - TimeUnit.DAYS.toMillis(1) // Yesterday
+    private val timeT4 = now - TimeUnit.DAYS.toMillis(2) // Day before yesterday
+
+    // Test data
+    private val sampleLog1 = AlertCheckLog(id = 1, checkedOn = timeT1, alertType = AlertType.BATTERY, isAlertSent = true, notifierType = NotifierType.EMAIL, status = "Sent", details = "Battery low: 10%")
+    private val sampleLog2 = AlertCheckLog(id = 2, checkedOn = timeT2, alertType = AlertType.STORAGE, isAlertSent = false, notifierType = null, status = "Not Sent", details = "Storage OK: 50%")
+    private val sampleLog3 = AlertCheckLog(id = 3, checkedOn = timeT3, alertType = AlertType.BATTERY, isAlertSent = true, notifierType = NotifierType.WEBHOOK, status = "Sent", details = "Battery low: 5%")
+    private val sampleLog4 = AlertCheckLog(id = 4, checkedOn = timeT4, alertType = AlertType.BATTERY, isAlertSent = false, notifierType = NotifierType.EMAIL, status = "Not Sent", details = "Battery OK: 30%")
+
+    private val allLogs = listOf(sampleLog1, sampleLog2, sampleLog3, sampleLog4).sortedByDescending { it.checkedOn } // Presenter sorts by default
+
+    @Before
+    fun setUp() {
+        navigator = mockk(relaxed = true)
+        appPreferencesDataStore = mockk()
+        remoteAlertRepository = mockk()
+        analytics = mockk(relaxed = true)
+
+        // Default mocks
+        every { appPreferencesDataStore.workerIntervalFlow() } returns flowOf(60L) // Default interval
+        every { remoteAlertRepository.getAllAlertCheckLogs() } returns flowOf(allLogs) // Default logs
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `initial state and data loading - starts loading, then shows logs and correct interval`() = runTest {
+        val initialLogsFlow = MutableStateFlow<List<AlertCheckLog>>(emptyList())
+        every { remoteAlertRepository.getAllAlertCheckLogs() } returns initialLogsFlow
+        val workerInterval = 90L
+        every { appPreferencesDataStore.workerIntervalFlow() } returns flowOf(workerInterval)
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            AlertCheckLogViewerPresenter(navigator, appPreferencesDataStore, remoteAlertRepository, analytics)
+        }.test {
+            var state = awaitItem() // Initial state before logs are emitted by flow
+            assertThat(state.isLoading).isTrue()
+            assertThat(state.logs).isEmpty()
+            assertThat(state.filteredLogs).isEmpty()
+            assertThat(state.checkIntervalMinutes).isEqualTo(workerInterval)
+            assertThat(state.showTriggeredOnly).isFalse()
+            assertThat(state.selectedAlertType).isNull()
+            assertThat(state.selectedNotifierType).isNull()
+            assertThat(state.dateRange).isNull()
+
+            // Emit logs
+            initialLogsFlow.value = allLogs
+            state = awaitItem() // State after logs are emitted
+
+            assertThat(state.isLoading).isFalse()
+            assertThat(state.logs).isEqualTo(allLogs)
+            assertThat(state.filteredLogs).isEqualTo(allLogs) // Initially no filters
+            assertThat(state.checkIntervalMinutes).isEqualTo(workerInterval)
+
+            // Impression effect
+            coVerify { analytics.logScreenView(AlertCheckLogViewerScreen::class) }
+        }
+    }
+
+    @Test
+    fun `event NavigateBack invokes navigator pop`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            AlertCheckLogViewerPresenter(navigator, appPreferencesDataStore, remoteAlertRepository, analytics)
+        }.test {
+            val state = awaitItem() // Consume initial state
+            state.eventSink(AlertCheckLogScreenEvent.NavigateBack)
+            coVerify { navigator.pop() }
+        }
+    }
+
+    @Test
+    fun `event ToggleTriggeredOnly filters logs to show only triggered alerts and back`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            AlertCheckLogViewerPresenter(navigator, appPreferencesDataStore, remoteAlertRepository, analytics)
+        }.test {
+            var state = awaitItem() // Initial state with all logs
+
+            // Toggle to show triggered only
+            state.eventSink(AlertCheckLogScreenEvent.ToggleTriggeredOnly)
+            state = awaitItem()
+            assertThat(state.showTriggeredOnly).isTrue()
+            assertThat(state.filteredLogs).containsExactlyElementsIn(allLogs.filter { it.isAlertSent })
+            assertThat(state.filteredLogs).containsExactly(sampleLog1, sampleLog3)
+
+
+            // Toggle back
+            state.eventSink(AlertCheckLogScreenEvent.ToggleTriggeredOnly)
+            state = awaitItem()
+            assertThat(state.showTriggeredOnly).isFalse()
+            assertThat(state.filteredLogs).isEqualTo(allLogs)
+        }
+    }
+
+    @Test
+    fun `event FilterByAlertType filters logs and clears filter`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            AlertCheckLogViewerPresenter(navigator, appPreferencesDataStore, remoteAlertRepository, analytics)
+        }.test {
+            var state = awaitItem()
+
+            // Filter by BATTERY
+            state.eventSink(AlertCheckLogScreenEvent.FilterByAlertType(AlertType.BATTERY))
+            state = awaitItem()
+            assertThat(state.selectedAlertType).isEqualTo(AlertType.BATTERY)
+            assertThat(state.filteredLogs).containsExactlyElementsIn(allLogs.filter { it.alertType == AlertType.BATTERY })
+            assertThat(state.filteredLogs).containsExactly(sampleLog1, sampleLog3, sampleLog4)
+
+
+            // Clear filter by passing null
+            state.eventSink(AlertCheckLogScreenEvent.FilterByAlertType(null))
+            state = awaitItem()
+            assertThat(state.selectedAlertType).isNull()
+            assertThat(state.filteredLogs).isEqualTo(allLogs)
+        }
+    }
+
+    @Test
+    fun `event FilterByNotifierType filters logs and clears filter`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            AlertCheckLogViewerPresenter(navigator, appPreferencesDataStore, remoteAlertRepository, analytics)
+        }.test {
+            var state = awaitItem()
+
+            // Filter by EMAIL
+            state.eventSink(AlertCheckLogScreenEvent.FilterByNotifierType(NotifierType.EMAIL))
+            state = awaitItem()
+            assertThat(state.selectedNotifierType).isEqualTo(NotifierType.EMAIL)
+            assertThat(state.filteredLogs).containsExactlyElementsIn(allLogs.filter { it.notifierType == NotifierType.EMAIL })
+            assertThat(state.filteredLogs).containsExactly(sampleLog1, sampleLog4)
+
+            // Clear filter by passing null
+            state.eventSink(AlertCheckLogScreenEvent.FilterByNotifierType(null))
+            state = awaitItem()
+            assertThat(state.selectedNotifierType).isNull()
+            assertThat(state.filteredLogs).isEqualTo(allLogs)
+        }
+    }
+
+    @Test
+    fun `event FilterByDateRange filters logs and clears filter`() = runTest {
+        // Using existing sampleLog timestamps: timeT0, timeT1, timeT2, timeT3, timeT4
+        // Range: from timeT3 (inclusive) to timeT1 (inclusive)
+        val startDate = timeT3
+        val endDate = timeT1
+
+        val expectedLogsInDateRange = allLogs.filter { it.checkedOn >= startDate && it.checkedOn <= endDate }
+                                            .sortedByDescending { it.checkedOn }
+        assertThat(expectedLogsInDateRange).containsExactly(sampleLog1, sampleLog3) // sampleLog2 is T2, sampleLog4 is T4
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            AlertCheckLogViewerPresenter(navigator, appPreferencesDataStore, remoteAlertRepository, analytics)
+        }.test {
+            var state = awaitItem()
+
+            state.eventSink(AlertCheckLogScreenEvent.FilterByDateRange(startDate, endDate))
+            state = awaitItem()
+            assertThat(state.dateRange).isNotNull()
+            assertThat(state.dateRange?.first).isEqualTo(startDate)
+            assertThat(state.dateRange?.second).isEqualTo(endDate)
+            assertThat(state.filteredLogs).isEqualTo(expectedLogsInDateRange)
+
+            // Clear filter
+            state.eventSink(AlertCheckLogScreenEvent.FilterByDateRange(null, null))
+            state = awaitItem()
+            assertThat(state.dateRange).isNull()
+            assertThat(state.filteredLogs).isEqualTo(allLogs)
+        }
+    }
+
+
+    @Test
+    fun `event ClearFilters resets all filters to default values`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            AlertCheckLogViewerPresenter(navigator, appPreferencesDataStore, remoteAlertRepository, analytics)
+        }.test {
+            var state = awaitItem()
+
+            // Apply some filters
+            state.eventSink(AlertCheckLogScreenEvent.ToggleTriggeredOnly) // showTriggeredOnly = true
+            state = awaitItem()
+            state.eventSink(AlertCheckLogScreenEvent.FilterByAlertType(AlertType.BATTERY))
+            state = awaitItem()
+            state.eventSink(AlertCheckLogScreenEvent.FilterByNotifierType(NotifierType.EMAIL))
+            state = awaitItem()
+            val testDate = System.currentTimeMillis()
+            state.eventSink(AlertCheckLogScreenEvent.FilterByDateRange(testDate - 1000, testDate))
+            state = awaitItem()
+
+
+            // Verify filters are applied (brief check, main focus is on clearing)
+            assertThat(state.showTriggeredOnly).isTrue()
+            assertThat(state.selectedAlertType).isEqualTo(AlertType.BATTERY)
+            assertThat(state.selectedNotifierType).isEqualTo(NotifierType.EMAIL)
+            assertThat(state.dateRange).isNotNull()
+
+            // Clear filters
+            state.eventSink(AlertCheckLogScreenEvent.ClearFilters)
+            state = awaitItem()
+
+            // Verify all filters are reset
+            assertThat(state.showTriggeredOnly).isFalse()
+            assertThat(state.selectedAlertType).isNull()
+            assertThat(state.selectedNotifierType).isNull()
+            assertThat(state.dateRange).isNull()
+            assertThat(state.filteredLogs).isEqualTo(allLogs) // Reverts to all logs
+        }
+    }
+
+    @Test
+    fun `event ExportLogs is processed without error`() = runTest {
+         moleculeFlow(RecompositionClock.Immediate) {
+            AlertCheckLogViewerPresenter(navigator, appPreferencesDataStore, remoteAlertRepository, analytics)
+        }.test {
+            val state = awaitItem()
+            // This event primarily triggers UI (like showing a share sheet or snackbar),
+            // which is not directly testable in the presenter.
+            // We just ensure the event is received and doesn't cause a crash.
+            state.eventSink(AlertCheckLogScreenEvent.ExportLogs)
+            // No specific state change in the presenter is expected for this event.
+            // We just consume any potential recomposition.
+            expectMostRecentItem()
+            // Analytics for export could be verified if added
+            // coVerify { analytics.logExportLogs() } // Example if such analytics existed
+        }
+    }
+
+    @Test
+    fun `combined filters work correctly - triggered, battery type, specific date`() = runTest {
+        // Test Data:
+        // sampleLog1: T1, BATTERY, isAlertSent = true, EMAIL
+        // sampleLog2: T2, STORAGE, isAlertSent = false, null
+        // sampleLog3: T3, BATTERY, isAlertSent = true, WEBHOOK
+        // sampleLog4: T4, BATTERY, isAlertSent = false, EMAIL
+
+        val filterDate = timeT1 // Exact date of sampleLog1
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            AlertCheckLogViewerPresenter(navigator, appPreferencesDataStore, remoteAlertRepository, analytics)
+        }.test {
+            var state = awaitItem()
+
+            // 1. Filter by showTriggeredOnly = true
+            state.eventSink(AlertCheckLogScreenEvent.ToggleTriggeredOnly)
+            state = awaitItem()
+            // Expected: sampleLog1, sampleLog3
+            assertThat(state.filteredLogs).containsExactly(sampleLog1, sampleLog3)
+
+            // 2. Additionally filter by AlertType = BATTERY
+            state.eventSink(AlertCheckLogScreenEvent.FilterByAlertType(AlertType.BATTERY))
+            state = awaitItem()
+            // Expected: sampleLog1, sampleLog3 (both are BATTERY)
+            assertThat(state.filteredLogs).containsExactly(sampleLog1, sampleLog3)
+
+            // 3. Additionally filter by a date range that ONLY includes sampleLog1 (timeT1)
+            // To make the range specific to a single day, set start and end of that day.
+            val cal = Calendar.getInstance().apply { timeInMillis = filterDate }
+            cal.set(Calendar.HOUR_OF_DAY, 0)
+            cal.set(Calendar.MINUTE, 0)
+            cal.set(Calendar.SECOND, 0)
+            cal.set(Calendar.MILLISECOND, 0)
+            val dayStart = cal.timeInMillis
+
+            cal.set(Calendar.HOUR_OF_DAY, 23)
+            cal.set(Calendar.MINUTE, 59)
+            cal.set(Calendar.SECOND, 59)
+            cal.set(Calendar.MILLISECOND, 999)
+            val dayEnd = cal.timeInMillis
+
+            state.eventSink(AlertCheckLogScreenEvent.FilterByDateRange(dayStart, dayEnd))
+            state = awaitItem()
+            // Expected: sampleLog1 (isAlertSent=true, type=BATTERY, checkedOn=timeT1)
+            assertThat(state.filteredLogs).containsExactly(sampleLog1)
+
+            // 4. Additionally filter by NotifierType = EMAIL (sampleLog1 is EMAIL)
+            state.eventSink(AlertCheckLogScreenEvent.FilterByNotifierType(NotifierType.EMAIL))
+            state = awaitItem()
+            assertThat(state.filteredLogs).containsExactly(sampleLog1) // Still sampleLog1
+
+            // 5. Change NotifierType to WEBHOOK (sampleLog1 is not WEBHOOK, so list should be empty)
+            state.eventSink(AlertCheckLogScreenEvent.FilterByNotifierType(NotifierType.WEBHOOK))
+            state = awaitItem()
+            assertThat(state.filteredLogs).isEmpty()
+
+            // Clear all filters
+            state.eventSink(AlertCheckLogScreenEvent.ClearFilters)
+            state = awaitItem()
+            assertThat(state.filteredLogs).isEqualTo(allLogs)
+        }
+    }
+}

--- a/app/src/test/java/dev/hossain/remotenotify/ui/alertlist/AlertsListPresenterTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/ui/alertlist/AlertsListPresenterTest.kt
@@ -1,0 +1,365 @@
+package dev.hossain.remotenotify.ui.alertlist
+
+import android.content.Context
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import app.cash.molecule.RecompositionClock
+import app.cash.molecule.moleculeFlow
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import dev.hossain.remotenotify.BuildConfig
+import dev.hossain.remotenotify.R
+import dev.hossain.remotenotify.RemoteNotifyApplication
+import dev.hossain.remotenotify.TestNavGraphs
+import dev.hossain.remotenotify.analytics.Analytics
+import dev.hossain.remotenotify.data.AppPreferencesDataStore
+import dev.hossain.remotenotify.data.RemoteAlert
+import dev.hossain.remotenotify.data.RemoteAlertRepository
+import dev.hossain.remotenotify.model.AlertCheckLog
+import dev.hossain.remotenotify.model.AlertType
+import dev.hossain.remotenotify.model.DeviceState
+import dev.hossain.remotenotify.model.NotificationSender
+import dev.hossain.remotenotify.model.NotifierType
+import dev.hossain.remotenotify.platform.BatteryMonitor
+import dev.hossain.remotenotify.platform.StorageMonitor
+import dev.hossain.remotenotify.service.DEVICE_VITALS_CHECKER_WORKER_ID
+import dev.hossain.remotenotify.ui.NavGraphs
+import dev.hossain.remotenotify.ui.about.AboutAppScreen
+import dev.hossain.remotenotify.ui.addalert.AddNewRemoteAlertScreen
+import dev.hossain.remotenotify.ui.alertchecklog.AlertCheckLogViewerScreen
+import dev.hossain.remotenotify.ui.notifmedium.NotificationMediumListScreen
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.UUID
+
+/**
+ * Unit tests for [AlertsListPresenter].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AlertsListPresenterTest {
+    private lateinit var navigator: Navigator
+    private lateinit var remoteAlertRepository: RemoteAlertRepository
+    private lateinit var batteryMonitor: BatteryMonitor
+    private lateinit var storageMonitor: StorageMonitor
+    private lateinit var mockNotifiers: Set<NotificationSender>
+    private lateinit var appPreferencesDataStore: AppPreferencesDataStore
+    private lateinit var analytics: Analytics
+    private lateinit var mockContext: Context
+    private lateinit var mockWorkManager: WorkManager
+
+    // Test data
+    private val sampleAlert1 = RemoteAlert.BatteryAlert(conditionId = "bat_low_1", threshold = 15, isEnabled = true)
+    private val sampleAlert2 = RemoteAlert.StorageAlert(conditionId = "sto_low_1", threshold = 10, isEnabled = true)
+    private val sampleAlerts = listOf(sampleAlert1, sampleAlert2)
+    private val sampleLog = AlertCheckLog(id = 1, checkedOn = System.currentTimeMillis(), alertType = AlertType.BATTERY, isAlertSent = true, notifierType = NotifierType.EMAIL, status = "Sent", details = "Battery low")
+
+    @Before
+    fun setUp() {
+        navigator = mockk(relaxed = true)
+        remoteAlertRepository = mockk(relaxed = true) // relaxed for deleteRemoteAlert
+        batteryMonitor = mockk()
+        storageMonitor = mockk()
+        mockNotifiers = emptySet() // Will be configured per test
+        appPreferencesDataStore = mockk(relaxed = true) // relaxed for markEducationDialogShown
+        analytics = mockk(relaxed = true)
+        // It's better to mock Application context if WorkManager requires it.
+        mockContext = mockk<RemoteNotifyApplication>(relaxed = true)
+        mockWorkManager = mockk()
+
+        // Mock static WorkManager.getInstance(context)
+        mockkStatic(WorkManager::class)
+        every { WorkManager.getInstance(mockContext) } returns mockWorkManager
+
+        // Default mocks for flows to prevent null pointer exceptions if not overridden by a specific test
+        coEvery { batteryMonitor.getBatteryLevel() } returns flowOf(DeviceState.BatteryLevel(80))
+        coEvery { storageMonitor.getAvailableStorageInGB() } returns flowOf(DeviceState.StorageSpace(200))
+        coEvery { storageMonitor.getTotalStorageInGB() } returns flowOf(DeviceState.StorageSpace(500))
+        coEvery { remoteAlertRepository.getAllRemoteAlertFlow() } returns emptyFlow()
+        coEvery { remoteAlertRepository.getLatestCheckLog() } returns emptyFlow()
+        every { mockWorkManager.getWorkInfosByTagFlow(DEVICE_VITALS_CHECKER_WORKER_ID) } returns emptyFlow()
+        coEvery { appPreferencesDataStore.isEducationDialogShown() } returns flowOf(false) // Default: not shown
+
+        // Mock NavGraphs to avoid "No NavGraph found" error if navigator.goTo is called
+        // This is crucial if your navigator extension functions rely on finding these graphs.
+        mockkStatic(NavGraphs::class)
+        every { NavGraphs.root } returns TestNavGraphs.Root // Assuming TestNavGraphs is a test utility
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    private fun createPresenter(): AlertsListPresenter {
+        return AlertsListPresenter(
+            navigator = navigator,
+            remoteAlertRepository = remoteAlertRepository,
+            batteryMonitor = batteryMonitor,
+            storageMonitor = storageMonitor,
+            notifiers = mockNotifiers,
+            appPreferences = appPreferencesDataStore,
+            analytics = analytics,
+            appContext = mockContext
+        )
+    }
+
+    @Test
+    fun `initial state - data loads, no notifier, education not shown -> showEducationSheet is true`() = runTest {
+        val batteryLvl = 75
+        val availStorage = 150
+        val totalStorage = 256
+        val workInfoList = listOf(WorkInfo(UUID.randomUUID(), WorkInfo.State.RUNNING, mutableMapOf(), mutableListOf(), 0))
+
+        coEvery { batteryMonitor.getBatteryLevel() } returns flowOf(DeviceState.BatteryLevel(batteryLvl))
+        coEvery { storageMonitor.getAvailableStorageInGB() } returns flowOf(DeviceState.StorageSpace(availStorage))
+        coEvery { storageMonitor.getTotalStorageInGB() } returns flowOf(DeviceState.StorageSpace(totalStorage))
+        coEvery { remoteAlertRepository.getAllRemoteAlertFlow() } returns flowOf(sampleAlerts)
+        coEvery { remoteAlertRepository.getLatestCheckLog() } returns flowOf(sampleLog)
+        every { mockWorkManager.getWorkInfosByTagFlow(DEVICE_VITALS_CHECKER_WORKER_ID) } returns flowOf(workInfoList)
+        coEvery { appPreferencesDataStore.isEducationDialogShown() } returns flowOf(false) // Education sheet NOT shown before
+
+        // No notifiers configured
+        val notifier1 = mockk<NotificationSender>()
+        every { notifier1.hasValidConfig() } returns false
+        mockNotifiers = setOf(notifier1)
+
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+
+            assertThat(state.remoteAlertConfigs).isEqualTo(sampleAlerts)
+            assertThat(state.batteryPercentage).isEqualTo(batteryLvl)
+            assertThat(state.availableStorage).isEqualTo(availStorage)
+            assertThat(state.totalStorage).isEqualTo(totalStorage)
+            assertThat(state.isAnyNotifierConfigured).isFalse()
+            assertThat(state.latestAlertCheckLog).isEqualTo(sampleLog)
+            assertThat(state.workerStatus).isEqualTo(WorkerStatus.WORKING) // RUNNING maps to WORKING
+            assertThat(state.showEducationSheet).isTrue() // Should show if not previously shown AND no notifier
+
+            coVerify { analytics.logScreenView(AlertsListScreen::class) } // Impression effect
+            coVerify { appPreferencesDataStore.isEducationDialogShown() }
+        }
+    }
+
+    @Test
+    fun `initial state - data loads, notifier configured, education not shown -> showEducationSheet is false`() = runTest {
+        coEvery { appPreferencesDataStore.isEducationDialogShown() } returns flowOf(false) // Education sheet NOT shown before
+
+        // At least one notifier configured
+        val notifier1 = mockk<NotificationSender>()
+        every { notifier1.hasValidConfig() } returns true // Configured
+        mockNotifiers = setOf(notifier1)
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            assertThat(state.isAnyNotifierConfigured).isTrue()
+            assertThat(state.showEducationSheet).isFalse() // Should NOT show if notifier is configured
+            coVerify { analytics.logScreenView(AlertsListScreen::class) }
+        }
+    }
+
+    @Test
+    fun `initial state - data loads, no notifier, education previously shown -> showEducationSheet is false`() = runTest {
+        coEvery { appPreferencesDataStore.isEducationDialogShown() } returns flowOf(true) // Education sheet SHOWN before
+
+        // No notifiers configured
+        val notifier1 = mockk<NotificationSender>()
+        every { notifier1.hasValidConfig() } returns false
+        mockNotifiers = setOf(notifier1)
+
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            assertThat(state.isAnyNotifierConfigured).isFalse()
+            assertThat(state.showEducationSheet).isFalse() // Should NOT show if previously shown
+            coVerify { analytics.logScreenView(AlertsListScreen::class) }
+        }
+    }
+
+
+    @Test
+    fun `event DeleteNotification calls repository delete`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem() // consume initial state
+            state.eventSink(AlertsListScreenEvent.DeleteNotification(sampleAlert1))
+            coVerify { remoteAlertRepository.deleteRemoteAlert(sampleAlert1) }
+        }
+    }
+
+    @Test
+    fun `event AddNotification navigates to AddNewRemoteAlertScreen`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(AlertsListScreenEvent.AddNotification)
+            verify { navigator.goTo(AddNewRemoteAlertScreen) }
+        }
+    }
+
+    @Test
+    fun `event AddNotificationDestination navigates to NotificationMediumListScreen`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(AlertsListScreenEvent.AddNotificationDestination)
+            verify { navigator.goTo(NotificationMediumListScreen) }
+        }
+    }
+
+    @Test
+    fun `event NavigateToAbout navigates to AboutAppScreen`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(AlertsListScreenEvent.NavigateToAbout)
+            verify { navigator.goTo(AboutAppScreen) }
+        }
+    }
+
+    @Test
+    fun `event DismissEducationSheet updates state, logs analytics, and marks as shown`() = runTest {
+        // Ensure sheet is shown initially for this test
+        coEvery { appPreferencesDataStore.isEducationDialogShown() } returns flowOf(false)
+        val notifier = mockk<NotificationSender>()
+        every { notifier.hasValidConfig() } returns false
+        mockNotifiers = setOf(notifier)
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            var state = awaitItem()
+            assertThat(state.showEducationSheet).isTrue() // Verify pre-condition
+
+            state.eventSink(AlertsListScreenEvent.DismissEducationSheet)
+            state = awaitItem() // Recomposition after event
+
+            assertThat(state.showEducationSheet).isFalse()
+            coVerify { analytics.logViewTutorial(isComplete = true) }
+            coVerify { appPreferencesDataStore.markEducationDialogShown() }
+        }
+    }
+
+    @Test
+    fun `event ShowEducationSheet updates state, logs analytics, and marks as shown`() = runTest {
+        // Ensure sheet is NOT shown initially for this test (e.g., already shown or notifier configured)
+        coEvery { appPreferencesDataStore.isEducationDialogShown() } returns flowOf(true) // Already shown
+        val notifier = mockk<NotificationSender>()
+        every { notifier.hasValidConfig() } returns true // Notifier configured
+        mockNotifiers = setOf(notifier)
+
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            var state = awaitItem()
+            assertThat(state.showEducationSheet).isFalse() // Verify pre-condition
+
+            state.eventSink(AlertsListScreenEvent.ShowEducationSheet)
+            state = awaitItem() // Recomposition after event
+
+            assertThat(state.showEducationSheet).isTrue()
+            coVerify { analytics.logViewTutorial(isComplete = false) }
+            coVerify { appPreferencesDataStore.markEducationDialogShown() } // As per current implementation
+        }
+    }
+
+    @Test
+    fun `event ViewAllLogs navigates to AlertCheckLogViewerScreen`() = runTest {
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(AlertsListScreenEvent.ViewAllLogs)
+            verify { navigator.goTo(AlertCheckLogViewerScreen) }
+        }
+    }
+
+    // Tests for workerStatus mapping
+    @Test
+    fun `workerStatus mapping - ENQUEUED results in WORKING`() = runTest {
+        val workInfoList = listOf(WorkInfo(UUID.randomUUID(), WorkInfo.State.ENQUEUED, mutableMapOf(), mutableListOf(), 0))
+        every { mockWorkManager.getWorkInfosByTagFlow(DEVICE_VITALS_CHECKER_WORKER_ID) } returns flowOf(workInfoList)
+        moleculeFlow(RecompositionClock.Immediate) { createPresenter().present() }.test {
+            assertThat(awaitItem().workerStatus).isEqualTo(WorkerStatus.WORKING)
+        }
+    }
+
+    @Test
+    fun `workerStatus mapping - RUNNING results in WORKING`() = runTest {
+        val workInfoList = listOf(WorkInfo(UUID.randomUUID(), WorkInfo.State.RUNNING, mutableMapOf(), mutableListOf(), 0))
+        every { mockWorkManager.getWorkInfosByTagFlow(DEVICE_VITALS_CHECKER_WORKER_ID) } returns flowOf(workInfoList)
+        moleculeFlow(RecompositionClock.Immediate) { createPresenter().present() }.test {
+            assertThat(awaitItem().workerStatus).isEqualTo(WorkerStatus.WORKING)
+        }
+    }
+
+    @Test
+    fun `workerStatus mapping - SUCCEEDED results in IDLE`() = runTest {
+        val workInfoList = listOf(WorkInfo(UUID.randomUUID(), WorkInfo.State.SUCCEEDED, mutableMapOf(), mutableListOf(), 0))
+        every { mockWorkManager.getWorkInfosByTagFlow(DEVICE_VITALS_CHECKER_WORKER_ID) } returns flowOf(workInfoList)
+        moleculeFlow(RecompositionClock.Immediate) { createPresenter().present() }.test {
+            assertThat(awaitItem().workerStatus).isEqualTo(WorkerStatus.IDLE)
+        }
+    }
+
+    @Test
+    fun `workerStatus mapping - FAILED results in ERROR`() = runTest {
+        val workInfoList = listOf(WorkInfo(UUID.randomUUID(), WorkInfo.State.FAILED, mutableMapOf(), mutableListOf(), 0))
+        every { mockWorkManager.getWorkInfosByTagFlow(DEVICE_VITALS_CHECKER_WORKER_ID) } returns flowOf(workInfoList)
+        moleculeFlow(RecompositionClock.Immediate) { createPresenter().present() }.test {
+            assertThat(awaitItem().workerStatus).isEqualTo(WorkerStatus.ERROR)
+        }
+    }
+
+    @Test
+    fun `workerStatus mapping - BLOCKED results in WORKING`() = runTest { // As per presenter logic
+        val workInfoList = listOf(WorkInfo(UUID.randomUUID(), WorkInfo.State.BLOCKED, mutableMapOf(), mutableListOf(), 0))
+        every { mockWorkManager.getWorkInfosByTagFlow(DEVICE_VITALS_CHECKER_WORKER_ID) } returns flowOf(workInfoList)
+        moleculeFlow(RecompositionClock.Immediate) { createPresenter().present() }.test {
+            assertThat(awaitItem().workerStatus).isEqualTo(WorkerStatus.WORKING)
+        }
+    }
+
+    @Test
+    fun `workerStatus mapping - CANCELLED results in IDLE`() = runTest { // As per presenter logic
+        val workInfoList = listOf(WorkInfo(UUID.randomUUID(), WorkInfo.State.CANCELLED, mutableMapOf(), mutableListOf(), 0))
+        every { mockWorkManager.getWorkInfosByTagFlow(DEVICE_VITALS_CHECKER_WORKER_ID) } returns flowOf(workInfoList)
+        moleculeFlow(RecompositionClock.Immediate) { createPresenter().present() }.test {
+            assertThat(awaitItem().workerStatus).isEqualTo(WorkerStatus.IDLE)
+        }
+    }
+
+    @Test
+    fun `workerStatus mapping - empty WorkInfo list results in UNKNOWN`() = runTest {
+        every { mockWorkManager.getWorkInfosByTagFlow(DEVICE_VITALS_CHECKER_WORKER_ID) } returns flowOf(emptyList())
+        moleculeFlow(RecompositionClock.Immediate) { createPresenter().present() }.test {
+            assertThat(awaitItem().workerStatus).isEqualTo(WorkerStatus.UNKNOWN)
+        }
+    }
+
+    // Impression effect (analytics.logScreenView) is verified in the initial state tests.
+}

--- a/app/src/test/java/dev/hossain/remotenotify/ui/alertmediumconfig/ConfigureNotificationMediumPresenterTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/ui/alertmediumconfig/ConfigureNotificationMediumPresenterTest.kt
@@ -1,0 +1,469 @@
+package dev.hossain.remotenotify.ui.alertmediumconfig
+
+import app.cash.molecule.RecompositionClock
+import app.cash.molecule.moleculeFlow
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import dev.hossain.remotenotify.R
+import dev.hossain.remotenotify.TestNavGraphs
+import dev.hossain.remotenotify.analytics.Analytics
+import dev.hossain.remotenotify.model.AlertMediumConfig
+import dev.hossain.remotenotify.model.EmailQuotaManager
+import dev.hossain.remotenotify.model.NotificationSender
+import dev.hossain.remotenotify.model.NotifierType
+import dev.hossain.remotenotify.utils.AlertFormatter
+import dev.hossain.remotenotify.utils.NotifierUtils.getNotifier
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+/**
+ * Tests for [ConfigureNotificationMediumPresenter].
+ * This test class is parameterized to run tests for each [NotifierType].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(Parameterized::class)
+class ConfigureNotificationMediumPresenterTest(private val currentNotifierType: NotifierType) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "NotifierType = {0}")
+        fun data(): Collection<NotifierType> {
+            return NotifierType.values().filter { it != NotifierType.UNKNOWN } // Exclude UNKNOWN as it's not configurable
+        }
+    }
+
+    private lateinit var navigator: Navigator
+    private lateinit var mockNotifiers: Set<@JvmSuppressWildcards NotificationSender>
+    private lateinit var mockNotifier: NotificationSender // Specific mock for the currentNotifierType
+    private lateinit var emailQuotaManager: EmailQuotaManager
+    private lateinit var alertFormatter: AlertFormatter
+    private lateinit var analytics: Analytics
+    private lateinit var screen: ConfigureNotificationMediumScreen
+
+    // Sample configs based on notifier type
+    private fun getSampleConfig(type: NotifierType): AlertMediumConfig {
+        return when (type) {
+            NotifierType.EMAIL -> AlertMediumConfig.EmailConfig(listOf("test@example.com"))
+            NotifierType.WEBHOOK_SLACK_WORKFLOW -> AlertMediumConfig.WebhookConfig("https://hooks.slack.com/workflows/...")
+            NotifierType.WEBHOOK_REST_API -> AlertMediumConfig.WebhookConfig("https://example.com/api/notify")
+            NotifierType.TELEGRAM -> AlertMediumConfig.TelegramConfig("12345:bot_token", "channel_id")
+            NotifierType.TWILIO -> AlertMediumConfig.TwilioConfig("AC123", "auth_token", "+15551234567", "+15557654321")
+            else -> throw IllegalArgumentException("Unsupported notifier type for sample config: $type")
+        }
+    }
+    private fun getInvalidSampleConfig(type: NotifierType): AlertMediumConfig {
+         return when (type) {
+            NotifierType.EMAIL -> AlertMediumConfig.EmailConfig(listOf("invalid-email"))
+            NotifierType.WEBHOOK_SLACK_WORKFLOW -> AlertMediumConfig.WebhookConfig("invalid-url")
+            NotifierType.WEBHOOK_REST_API -> AlertMediumConfig.WebhookConfig("invalid-url")
+            NotifierType.TELEGRAM -> AlertMediumConfig.TelegramConfig("", "")
+            NotifierType.TWILIO -> AlertMediumConfig.TwilioConfig("", "", "", "")
+            else -> throw IllegalArgumentException("Unsupported notifier type for sample config: $type")
+        }
+    }
+
+    private val sampleJsonPayload = "{ \"message\": \"Test notification\" }"
+
+    @Before
+    fun setUp() {
+        navigator = mockk(relaxed = true)
+        mockNotifier = mockk(relaxed = true) // Individual mock for the parameterized type
+        mockNotifiers = setOf(mockNotifier) // Set containing only the current type's mock
+        emailQuotaManager = mockk(relaxed = true)
+        alertFormatter = mockk()
+        analytics = mockk(relaxed = true)
+        screen = ConfigureNotificationMediumScreen(currentNotifierType)
+
+
+        // Mock static NavGraphs
+        mockkStatic(TestNavGraphs::class) // Assuming TestNavGraphs.Root exists
+        every { TestNavGraphs.root } returns mockk()
+
+
+        // Mock static getNotifier to return our specific mockNotifier for the current type
+        mockkStatic("dev.hossain.remotenotify.utils.NotifierUtilsKt")
+        every { mockNotifiers.getNotifier(currentNotifierType) } returns mockNotifier
+
+        // Default mock for alertFormatter for webhook types
+        if (currentNotifierType.name.startsWith("WEBHOOK")) {
+            every { alertFormatter.format(any(), any(), any(), any()) } returns sampleJsonPayload
+        }
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    private fun createPresenter(): ConfigureNotificationMediumPresenter {
+        return ConfigureNotificationMediumPresenter(
+            screen = screen,
+            navigator = navigator,
+            notifiers = mockNotifiers,
+            emailQuotaManager = emailQuotaManager,
+            alertFormatter = alertFormatter,
+            analytics = analytics
+        )
+    }
+
+    // region Initial State Tests
+    @Test
+    fun `initial state - when notifier IS configured`() = runTest {
+        val sampleConfig = getSampleConfig(currentNotifierType)
+        every { mockNotifier.hasValidConfig() } returns true
+        every { mockNotifier.getConfig() } returns sampleConfig
+        every { mockNotifier.validateConfig(sampleConfig) } returns ConfigValidationResult(true)
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            assertThat(state.notifierType).isEqualTo(currentNotifierType)
+            assertThat(state.isConfigured).isTrue()
+            assertThat(state.configValidationResult.isValid).isTrue()
+            assertThat(state.alertMediumConfig).isEqualTo(sampleConfig)
+            assertThat(state.showValidationError).isFalse()
+            if (currentNotifierType.name.startsWith("WEBHOOK")) {
+                assertThat(state.sampleJsonPayload).isEqualTo(sampleJsonPayload)
+                verify { alertFormatter.format(any(), any(), any(), any()) }
+            } else {
+                assertThat(state.sampleJsonPayload).isNull()
+            }
+            assertThat(state.snackbarMessage).isNull()
+
+            coVerify { analytics.logScreenView(ConfigureNotificationMediumScreen::class) } // Impression
+        }
+    }
+
+    @Test
+    fun `initial state - when notifier IS NOT configured`() = runTest {
+        every { mockNotifier.hasValidConfig() } returns false
+        every { mockNotifier.getConfig() } returns null // No config when not configured
+        // Validate with a default/empty config for the type if necessary, or expect null
+        val defaultConfigForType = when(currentNotifierType) {
+            NotifierType.EMAIL -> AlertMediumConfig.EmailConfig()
+            NotifierType.WEBHOOK_SLACK_WORKFLOW, NotifierType.WEBHOOK_REST_API -> AlertMediumConfig.WebhookConfig()
+            NotifierType.TELEGRAM -> AlertMediumConfig.TelegramConfig()
+            NotifierType.TWILIO -> AlertMediumConfig.TwilioConfig()
+            else -> null
+        }
+        every { mockNotifier.validateConfig(defaultConfigForType) } returns ConfigValidationResult(false, R.string.error_invalid_config_generic)
+
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            assertThat(state.notifierType).isEqualTo(currentNotifierType)
+            assertThat(state.isConfigured).isFalse()
+            assertThat(state.configValidationResult.isValid).isFalse() // Default validation for empty config
+            assertThat(state.alertMediumConfig).isEqualTo(defaultConfigForType) // Should be default/empty
+            assertThat(state.showValidationError).isFalse()
+            if (currentNotifierType.name.startsWith("WEBHOOK")) {
+                assertThat(state.sampleJsonPayload).isEqualTo(sampleJsonPayload)
+            }
+            assertThat(state.snackbarMessage).isNull()
+            coVerify { analytics.logScreenView(ConfigureNotificationMediumScreen::class) } // Impression
+        }
+    }
+    // endregion Initial State Tests
+
+    // region Event Handling Tests
+    @Test
+    fun `event UpdateConfigValue - updates config, resets validation error, re-validates`() = runTest {
+        val initialConfig = getInvalidSampleConfig(currentNotifierType) // Start with some config
+        val newConfig = getSampleConfig(currentNotifierType)
+        val validationResultForNewConfig = ConfigValidationResult(true)
+
+        every { mockNotifier.getConfig() } returns initialConfig // Initial config
+        every { mockNotifier.validateConfig(initialConfig) } returns ConfigValidationResult(false, R.string.error_invalid_config_generic)
+        every { mockNotifier.validateConfig(newConfig) } returns validationResultForNewConfig
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            var state = awaitItem() // Initial state
+            // Simulate showing validation error from a previous failed save attempt
+            state.eventSink(ConfigureNotificationMediumScreenEvent.SaveConfig(initialConfig)) // This will set showValidationError = true
+            state = awaitItem()
+            assertThat(state.showValidationError).isTrue()
+
+
+            state.eventSink(ConfigureNotificationMediumScreenEvent.UpdateConfigValue(newConfig))
+            state = awaitItem()
+
+            assertThat(state.alertMediumConfig).isEqualTo(newConfig)
+            assertThat(state.showValidationError).isFalse() // Should reset
+            assertThat(state.configValidationResult).isEqualTo(validationResultForNewConfig)
+            verify { mockNotifier.validateConfig(newConfig) }
+        }
+    }
+
+    @Test
+    fun `event SaveConfig - validation fails - shows error, does not save or pop`() = runTest {
+        val invalidConfig = getInvalidSampleConfig(currentNotifierType)
+        every { mockNotifier.validateConfig(invalidConfig) } returns ConfigValidationResult(false, R.string.error_invalid_config_url)
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(ConfigureNotificationMediumScreenEvent.SaveConfig(invalidConfig))
+            val updatedState = awaitItem()
+
+            assertThat(updatedState.showValidationError).isTrue()
+            assertThat(updatedState.configValidationResult.errorMessageRes).isEqualTo(R.string.error_invalid_config_url)
+            coVerify(exactly = 0) { mockNotifier.saveConfig(any()) }
+            verify(exactly = 0) { navigator.pop(any()) }
+        }
+    }
+
+    @Test
+    fun `event SaveConfig - validation succeeds, save fails - shows snackbar error, does not pop`() = runTest {
+        val validConfig = getSampleConfig(currentNotifierType)
+        every { mockNotifier.validateConfig(validConfig) } returns ConfigValidationResult(true)
+        coEvery { mockNotifier.saveConfig(validConfig) } throws RuntimeException("Save failed")
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(ConfigureNotificationMediumScreenEvent.SaveConfig(validConfig))
+            val updatedState = awaitItem()
+
+            assertThat(updatedState.snackbarMessage).isEqualTo(R.string.error_failed_to_save_config)
+            assertThat(updatedState.showValidationError).isFalse() // Should not be a validation error
+            coVerify(exactly = 1) { mockNotifier.saveConfig(validConfig) }
+            verify(exactly = 0) { navigator.pop(any()) }
+        }
+    }
+
+    @Test
+    fun `event SaveConfig - validation and save succeed - logs analytics, pops with Configured result`() = runTest {
+        val validConfig = getSampleConfig(currentNotifierType)
+        every { mockNotifier.validateConfig(validConfig) } returns ConfigValidationResult(true)
+        coEvery { mockNotifier.saveConfig(validConfig) } returns Unit // Success
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(ConfigureNotificationMediumScreenEvent.SaveConfig(validConfig))
+            // No new state expected after pop
+
+            coVerify { analytics.logNotifierConfigured(currentNotifierType) }
+            coVerify { mockNotifier.saveConfig(validConfig) }
+            val popSlot = slot<ConfigurationResult>()
+            verify { navigator.pop(capture(popSlot)) }
+            assertThat(popSlot.captured).isInstanceOf(ConfigurationResult.Configured::class.java)
+            assertThat((popSlot.captured as ConfigurationResult.Configured).notifierType).isEqualTo(currentNotifierType)
+        }
+    }
+
+    @Test
+    fun `event TestConfig - EMAIL - quota invalid - shows snackbar`() = runTest {
+        if (currentNotifierType != NotifierType.EMAIL) return@runTest // Test only for EMAIL
+
+        val emailConfig = getSampleConfig(NotifierType.EMAIL) as AlertMediumConfig.EmailConfig
+        every { mockNotifier.getConfig() } returns emailConfig
+        every { mockNotifier.validateConfig(emailConfig) } returns ConfigValidationResult(true)
+        coEvery { emailQuotaManager.validateQuota(emailConfig.emailAddresses.size) } returns EmailQuotaManager.QuotaValidationResult(false, 0, 5, R.string.error_email_quota_exceeded)
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(ConfigureNotificationMediumScreenEvent.TestConfig)
+            val updatedState = awaitItem()
+
+            assertThat(updatedState.snackbarMessage).isEqualTo(R.string.error_email_quota_exceeded)
+            coVerify(exactly = 0) { mockNotifier.sendNotification(any(), any()) }
+        }
+    }
+
+    @Test
+    fun `event TestConfig - EMAIL - quota valid, send success - shows success snackbar`() = runTest {
+        if (currentNotifierType != NotifierType.EMAIL) return@runTest
+
+        val emailConfig = getSampleConfig(NotifierType.EMAIL) as AlertMediumConfig.EmailConfig
+        every { mockNotifier.getConfig() } returns emailConfig
+        every { mockNotifier.validateConfig(emailConfig) } returns ConfigValidationResult(true)
+        coEvery { emailQuotaManager.validateQuota(emailConfig.emailAddresses.size) } returns EmailQuotaManager.QuotaValidationResult(true)
+        coEvery { mockNotifier.sendNotification(any(), any()) } returns true // Send success
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(ConfigureNotificationMediumScreenEvent.TestConfig)
+            val updatedState = awaitItem()
+
+            assertThat(updatedState.snackbarMessage).isEqualTo(R.string.msg_test_notification_sent)
+            coVerify { mockNotifier.sendNotification(emailConfig, any()) }
+            coVerify { mockNotifier.saveConfig(emailConfig) } // Test saves config first
+        }
+    }
+
+    @Test
+    fun `event TestConfig - EMAIL - quota valid, send fails - shows failure snackbar`() = runTest {
+        if (currentNotifierType != NotifierType.EMAIL) return@runTest
+
+        val emailConfig = getSampleConfig(NotifierType.EMAIL) as AlertMediumConfig.EmailConfig
+        every { mockNotifier.getConfig() } returns emailConfig
+        every { mockNotifier.validateConfig(emailConfig) } returns ConfigValidationResult(true)
+        coEvery { emailQuotaManager.validateQuota(emailConfig.emailAddresses.size) } returns EmailQuotaManager.QuotaValidationResult(true)
+        coEvery { mockNotifier.sendNotification(any(), any()) } returns false // Send fails
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(ConfigureNotificationMediumScreenEvent.TestConfig)
+            val updatedState = awaitItem()
+
+            assertThat(updatedState.snackbarMessage).isEqualTo(R.string.error_failed_to_send_test_notification)
+        }
+    }
+
+    @Test
+    fun `event TestConfig - Non-EMAIL - send success - shows success snackbar`() = runTest {
+        if (currentNotifierType == NotifierType.EMAIL) return@runTest // Test for non-EMAIL types
+
+        val config = getSampleConfig(currentNotifierType)
+        every { mockNotifier.getConfig() } returns config
+        every { mockNotifier.validateConfig(config) } returns ConfigValidationResult(true)
+        coEvery { mockNotifier.sendNotification(any(), any()) } returns true // Send success
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(ConfigureNotificationMediumScreenEvent.TestConfig)
+            val updatedState = awaitItem()
+
+            assertThat(updatedState.snackbarMessage).isEqualTo(R.string.msg_test_notification_sent)
+            coVerify { mockNotifier.sendNotification(config, any()) }
+            coVerify { mockNotifier.saveConfig(config) } // Test saves config first
+        }
+    }
+
+    @Test
+    fun `event TestConfig - Non-EMAIL - send fails - shows failure snackbar`() = runTest {
+        if (currentNotifierType == NotifierType.EMAIL) return@runTest
+
+        val config = getSampleConfig(currentNotifierType)
+        every { mockNotifier.getConfig() } returns config
+        every { mockNotifier.validateConfig(config) } returns ConfigValidationResult(true)
+        coEvery { mockNotifier.sendNotification(any(), any()) } returns false // Send fails
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(ConfigureNotificationMediumScreenEvent.TestConfig)
+            val updatedState = awaitItem()
+
+            assertThat(updatedState.snackbarMessage).isEqualTo(R.string.error_failed_to_send_test_notification)
+        }
+    }
+    
+    @Test
+    fun `event TestConfig - any type - send throws exception - shows error snackbar`() = runTest {
+        val config = getSampleConfig(currentNotifierType)
+        every { mockNotifier.getConfig() } returns config
+        every { mockNotifier.validateConfig(config) } returns ConfigValidationResult(true)
+        if (currentNotifierType == NotifierType.EMAIL) {
+             coEvery { emailQuotaManager.validateQuota(any()) } returns EmailQuotaManager.QuotaValidationResult(true)
+        }
+        coEvery { mockNotifier.sendNotification(any(), any()) } throws RuntimeException("Network error")
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(ConfigureNotificationMoldelScreenEvent.TestConfig)
+            val updatedState = awaitItem()
+
+            assertThat(updatedState.snackbarMessage).isEqualTo(R.string.error_failed_to_send_test_notification)
+        }
+    }
+
+
+    @Test
+    fun `event DismissSnackbar - clears snackbarMessage`() = runTest {
+        // Initial setup to show a snackbar message
+        val config = getSampleConfig(currentNotifierType)
+        every { mockNotifier.getConfig() } returns config
+        every { mockNotifier.validateConfig(config) } returns ConfigValidationResult(true)
+        if (currentNotifierType == NotifierType.EMAIL) {
+             coEvery { emailQuotaManager.validateQuota(any()) } returns EmailQuotaManager.QuotaValidationResult(true)
+        }
+        coEvery { mockNotifier.sendNotification(any(), any()) } returns false // Make it fail to show snackbar
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            var state = awaitItem()
+            state.eventSink(ConfigureNotificationMediumScreenEvent.TestConfig) // Trigger snackbar
+            state = awaitItem()
+            assertThat(state.snackbarMessage).isNotNull()
+
+            state.eventSink(ConfigureNotificationMediumScreenEvent.DismissSnackbar)
+            state = awaitItem()
+            assertThat(state.snackbarMessage).isNull()
+        }
+    }
+
+    @Test
+    fun `event NavigateBack - when configured - pops with Configured result`() = runTest {
+        every { mockNotifier.hasValidConfig() } returns true // Initial state is configured
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            assertThat(state.isConfigured).isTrue() // Verify precondition
+
+            state.eventSink(ConfigureNotificationMediumScreenEvent.NavigateBack)
+            // No new state expected
+
+            val popSlot = slot<ConfigurationResult>()
+            verify { navigator.pop(capture(popSlot)) }
+            assertThat(popSlot.captured).isInstanceOf(ConfigurationResult.Configured::class.java)
+            assertThat((popSlot.captured as ConfigurationResult.Configured).notifierType).isEqualTo(currentNotifierType)
+        }
+    }
+
+    @Test
+    fun `event NavigateBack - when NOT configured - pops with NotConfigured result`() = runTest {
+        every { mockNotifier.hasValidConfig() } returns false // Initial state is not configured
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            assertThat(state.isConfigured).isFalse() // Verify precondition
+
+            state.eventSink(ConfigureNotificationMediumScreenEvent.NavigateBack)
+            // No new state expected
+
+            val popSlot = slot<ConfigurationResult>()
+            verify { navigator.pop(capture(popSlot)) }
+            assertThat(popSlot.captured).isEqualTo(ConfigurationResult.NotConfigured)
+        }
+    }
+    // endregion Event Handling Tests
+}

--- a/app/src/test/java/dev/hossain/remotenotify/ui/alertmediumlist/NotificationMediumListPresenterTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/ui/alertmediumlist/NotificationMediumListPresenterTest.kt
@@ -1,0 +1,368 @@
+package dev.hossain.remotenotify.ui.alertmediumlist
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import app.cash.molecule.RecompositionClock
+import app.cash.molecule.moleculeFlow
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.ramcosta.composedestinations.navigation.DestinationsNavigator
+import dev.hossain.remotenotify.R
+import dev.hossain.remotenotify.TestNavGraphs
+import dev.hossain.remotenotify.analytics.Analytics
+import dev.hossain.remotenotify.data.AppPreferencesDataStore
+import dev.hossain.remotenotify.model.AlertMediumConfig
+import dev.hossain.remotenotify.model.NotificationSender
+import dev.hossain.remotenotify.model.NotifierType
+import dev.hossain.remotenotify.service.PeriodicWorkRequestManager
+import dev.hossain.remotenotify.ui.NavGraphs
+import dev.hossain.remotenotify.ui.alertmediumconfig.ConfigureNotificationMediumScreen
+import dev.hossain.remotenotify.ui.alertmediumconfig.ConfigurationResult
+import dev.hossain.remotenotify.ui.alertmediumconfig.rememberAnsweringNavigator
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [NotificationMediumListPresenter].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NotificationMediumListPresenterTest {
+
+    private lateinit var navigator: DestinationsNavigator
+    private lateinit var appPreferencesDataStore: AppPreferencesDataStore
+    private lateinit var mockNotifiers: Set<@JvmSuppressWildcards NotificationSender>
+    private lateinit var analytics: Analytics
+    private lateinit var mockContext: Context
+
+    // Individual mock senders for easier verification
+    private lateinit var emailNotifier: NotificationSender
+    private lateinit var webhookNotifier: NotificationSender
+    private lateinit var telegramNotifier: NotificationSender
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        navigator = mockk(relaxed = true)
+        appPreferencesDataStore = mockk(relaxed = true) // relaxed for saveWorkerInterval
+        analytics = mockk(relaxed = true)
+        mockContext = mockk(relaxed = true)
+
+        // Mock individual notifiers
+        emailNotifier = mockk(name = "EmailNotifier", relaxed = true) {
+            every { type } returns NotifierType.EMAIL
+            every { displayName } returns R.string.notifier_email_name // Assuming these are actual string res IDs
+            every { icon } returns R.drawable.ic_email // Assuming these are actual drawable res IDs
+        }
+        webhookNotifier = mockk(name = "WebhookNotifier", relaxed = true) {
+            every { type } returns NotifierType.WEBHOOK_REST_API
+            every { displayName } returns R.string.notifier_webhook_name
+            every { icon } returns R.drawable.ic_webhook
+        }
+        telegramNotifier = mockk(name = "TelegramNotifier", relaxed = true) {
+            every { type } returns NotifierType.TELEGRAM
+            every { displayName } returns R.string.notifier_telegram_name
+            every { icon } returns R.drawable.ic_telegram
+        }
+        mockNotifiers = setOf(emailNotifier, webhookNotifier, telegramNotifier)
+
+        // Default mock for worker interval
+        coEvery { appPreferencesDataStore.workerIntervalFlow() } returns flowOf(60L)
+
+        // Mock static NavGraphs
+        mockkStatic(NavGraphs::class)
+        every { NavGraphs.root } returns TestNavGraphs.Root
+
+        // Mock static rememberAnsweringNavigator - this is tricky.
+        // We'll mock the extension function itself if possible, or test its effects via the navigator it uses.
+        // For now, we assume `rememberAnsweringNavigator` correctly calls `navigator.navigate`
+        // and we will verify the `navigator.navigate` call.
+        // The callback part will be tested by simulating the pop result.
+
+        // Mock static PeriodicWorkRequestManager.sendPeriodicWorkRequest
+        mockkStatic(PeriodicWorkRequestManager::class)
+        every { PeriodicWorkRequestManager.sendPeriodicWorkRequest(any(), any()) } just Runs
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    private fun createPresenter(
+        mockedNavigator: DestinationsNavigator = navigator,
+        // This allows us to inject a navigator that we can control for callback testing
+        answeringNavigatorProvider: @Composable (callback: (ConfigurationResult) -> Unit) -> DestinationsNavigator = { callback ->
+            rememberAnsweringNavigator(mockedNavigator, callback)
+        }
+    ): NotificationMediumListPresenter {
+        return NotificationMediumListPresenter(
+            navigator = mockedNavigator,
+            appPreferences = appPreferencesDataStore,
+            notifiers = mockNotifiers,
+            analytics = analytics,
+            appContext = mockContext,
+            // Provide the answeringNavigatorProvider to the presenter
+            configureMediumNavigatorProvider = answeringNavigatorProvider
+        )
+    }
+
+    @Test
+    fun `initial state - loads worker interval and notifier configs correctly`() = runTest(testDispatcher) {
+        val initialInterval = 30L
+        coEvery { appPreferencesDataStore.workerIntervalFlow() } returns flowOf(initialInterval)
+
+        // Configure Email Notifier
+        val emailConfig = mockk<AlertMediumConfig.EmailConfig>()
+        every { emailConfig.configPreviewText(mockContext) } returns "test@example.com"
+        every { emailNotifier.hasValidConfig() } returns true
+        every { emailNotifier.getConfig() } returns emailConfig
+
+        // Webhook Notifier - Not configured
+        every { webhookNotifier.hasValidConfig() } returns false
+        every { webhookNotifier.getConfig() } returns null
+
+        // Telegram Notifier - Configured
+        val telegramConfig = mockk<AlertMediumConfig.TelegramConfig>()
+        every { telegramConfig.configPreviewText(mockContext) } returns "@channel_id"
+        every { telegramNotifier.hasValidConfig() } returns true
+        every { telegramNotifier.getConfig() } returns telegramConfig
+
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+
+            assertThat(state.workerIntervalMinutes).isEqualTo(initialInterval)
+            assertThat(state.notifiers).hasSize(3)
+
+            // Order is by displayName, assume Email, Telegram, Webhook for this example
+            // This part is tricky as it depends on actual string resource values and sorting.
+            // For robustness, find by type or verify properties individually.
+            val emailState = state.notifiers.find { it.type == NotifierType.EMAIL }!!
+            assertThat(emailState.isConfigured).isTrue()
+            assertThat(emailState.configPreviewText).isEqualTo("test@example.com")
+
+            val webhookState = state.notifiers.find { it.type == NotifierType.WEBHOOK_REST_API }!!
+            assertThat(webhookState.isConfigured).isFalse()
+            assertThat(webhookState.configPreviewText).isNull()
+
+            val telegramState = state.notifiers.find { it.type == NotifierType.TELEGRAM }!!
+            assertThat(telegramState.isConfigured).isTrue()
+            assertThat(telegramState.configPreviewText).isEqualTo("@channel_id")
+
+            coVerify { analytics.logScreenView(NotificationMediumListScreen::class) } // Impression
+        }
+    }
+
+    @Test
+    fun `event EditMediumConfig - navigates to ConfigureNotificationMediumScreen`() = runTest(testDispatcher) {
+        // We need to capture the navigator that rememberAnsweringNavigator uses internally
+        // or ensure our mock `navigator` is the one being called.
+        val capturedNavigator = mockk<DestinationsNavigator>(relaxed = true)
+        val presenter = createPresenter(mockedNavigator = capturedNavigator)
+
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            presenter.present()
+        }.test {
+            val state = awaitItem()
+            val targetNotifierType = NotifierType.EMAIL
+            state.eventSink(NotificationMediumListScreenEvent.EditMediumConfig(targetNotifierType))
+
+            val slot = slot<Any>() // Use Any for the destination type
+            verify { capturedNavigator.navigate(capture(slot), any(), any(), any()) }
+
+            // Check if the captured destination matches ConfigureNotificationMediumScreen(targetNotifierType)
+            // This requires ConfigureNotificationMediumScreen to be a data class or have a meaningful equals/toString
+            val capturedDestination = slot.captured
+            assertThat(capturedDestination).isInstanceOf(ConfigureNotificationMediumScreen::class.java)
+            assertThat((capturedDestination as ConfigureNotificationMediumScreen).notifierType).isEqualTo(targetNotifierType)
+        }
+    }
+
+    @Test
+    fun `event ResetMediumConfig - clears config, updates state`() = runTest(testDispatcher) {
+        // Email notifier initially configured
+        val emailConfig = mockk<AlertMediumConfig.EmailConfig>()
+        every { emailConfig.configPreviewText(mockContext) } returns "initial@config.com"
+        every { emailNotifier.hasValidConfig() } returns true
+        every { emailNotifier.getConfig() } returns emailConfig
+        coEvery { emailNotifier.clearConfig() } returns Unit // Mock clearConfig
+
+        // Other notifiers (e.g., webhook) not configured for simplicity in this test
+        every { webhookNotifier.hasValidConfig() } returns false
+        every { telegramNotifier.hasValidConfig() } returns false
+
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            var state = awaitItem()
+            val emailStateBeforeReset = state.notifiers.find { it.type == NotifierType.EMAIL }!!
+            assertThat(emailStateBeforeReset.isConfigured).isTrue()
+
+            state.eventSink(NotificationMediumListScreenEvent.ResetMediumConfig(NotifierType.EMAIL))
+            state = awaitItem() // Recomposition
+
+            coVerify { emailNotifier.clearConfig() }
+            val emailStateAfterReset = state.notifiers.find { it.type == NotifierType.EMAIL }!!
+            assertThat(emailStateAfterReset.isConfigured).isFalse()
+            assertThat(emailStateAfterReset.configPreviewText).isNull()
+        }
+    }
+
+    @Test
+    fun `event OnWorkerIntervalUpdated - debounces and calls save and sendPeriodicWorkRequest`() = runTest(testDispatcher) {
+        val initialInterval = 60L
+        val newInterval = 30L
+        coEvery { appPreferencesDataStore.workerIntervalFlow() } returns flowOf(initialInterval)
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+
+            // Update interval but don't advance time yet
+            state.eventSink(NotificationMediumListScreenEvent.OnWorkerIntervalUpdated(newInterval))
+            coVerify(exactly = 0) { appPreferencesDataStore.saveWorkerInterval(any()) }
+            verify(exactly = 0) { PeriodicWorkRequestManager.sendPeriodicWorkRequest(any(), any()) }
+
+            // Advance time by more than debounce duration (1000ms)
+            advanceTimeBy(1001)
+
+            coVerify { appPreferencesDataStore.saveWorkerInterval(newInterval) }
+            verify { PeriodicWorkRequestManager.sendPeriodicWorkRequest(mockContext, newInterval) }
+        }
+    }
+
+    @Test
+    fun `event ShareFeedback - logs analytics`() = runTest(testDispatcher) {
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(NotificationMediumListScreenEvent.ShareFeedback)
+            coVerify { analytics.logSendFeedback() }
+        }
+    }
+
+    @Test
+    fun `event NavigateBack - calls navigator pop`() = runTest(testDispatcher) {
+        moleculeFlow(RecompositionClock.Immediate) {
+            createPresenter().present()
+        }.test {
+            val state = awaitItem()
+            state.eventSink(NotificationMediumListScreenEvent.NavigateBack)
+            verify { navigator.pop() }
+        }
+    }
+
+    @Test
+    fun `rememberAnsweringNavigator callback - Configured result - calls sendPeriodicWorkRequest`() = runTest(testDispatcher) {
+        val currentInterval = 45L
+        coEvery { appPreferencesDataStore.workerIntervalFlow() } returns flowOf(currentInterval)
+
+        // This flow will simulate the callback from ConfigureNotificationMediumScreen
+        val mockConfigurationResultFlow = MutableSharedFlow<ConfigurationResult>(replay = 1)
+
+        // Custom provider for rememberAnsweringNavigator
+        val testAnsweringNavigatorProvider: @Composable (callback: (ConfigurationResult) -> Unit) -> DestinationsNavigator = { callback ->
+            // This mock navigator will be used by EditMediumConfig
+            val mockDestinationsNavigator = mockk<DestinationsNavigator>(relaxed = true)
+            // Simulate the callback being invoked when ConfigureNotificationMediumScreen would pop
+            // This requires a way to trigger `callback(result)` when `mockDestinationsNavigator.popBackStack(result)` would be called.
+            // A simpler way is to directly invoke the callback for testing purposes.
+            // We'll use the flow to emit the result as if it came from the popped screen.
+            mockConfigurationResultFlow.tryEmit(ConfigurationResult.Configured(NotifierType.EMAIL)) // Emit after presenter starts collecting
+            mockDestinationsNavigator // return a navigator, though its navigate call might be what we verify for EditMediumConfig
+        }
+
+
+        val presenter = NotificationMediumListPresenter(
+            navigator = navigator, // Main navigator
+            appPreferences = appPreferencesDataStore,
+            notifiers = mockNotifiers,
+            analytics = analytics,
+            appContext = mockContext,
+            configureMediumNavigatorProvider = { callback ->
+                // This is the navigator that will be used by EditMediumConfig
+                // When EditMediumConfig calls goTo on this, we want to eventually trigger the callback
+                // For this test, we will manually trigger the callback after the presenter is set up.
+                val internalNavigator = mockk<DestinationsNavigator>(relaxed = true)
+                // Simulate the callback being invoked
+                // This is the core of testing rememberAnsweringNavigator's callback behavior
+                // We need to ensure this callback is the one passed to the presenter.
+                callback(ConfigurationResult.Configured(NotifierType.EMAIL)) // Directly invoke for test
+                internalNavigator
+            }
+        )
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            presenter.present()
+        }.test {
+            awaitItem() // Consume initial state
+
+            // The callback should have been invoked during the composition of the presenter due to the direct call.
+            // Verify sendPeriodicWorkRequest was called with the current interval
+            verify(timeout(100)) { // Add timeout for coroutine execution
+                PeriodicWorkRequestManager.sendPeriodicWorkRequest(mockContext, currentInterval)
+            }
+        }
+    }
+
+
+    @Test
+    fun `rememberAnsweringNavigator callback - NotConfigured result - no additional actions`() = runTest(testDispatcher) {
+        val currentInterval = 45L
+        coEvery { appPreferencesDataStore.workerIntervalFlow() } returns flowOf(currentInterval)
+
+        val presenter = NotificationMediumListPresenter(
+            navigator = navigator,
+            appPreferences = appPreferencesDataStore,
+            notifiers = mockNotifiers,
+            analytics = analytics,
+            appContext = mockContext,
+            configureMediumNavigatorProvider = { callback ->
+                val internalNavigator = mockk<DestinationsNavigator>(relaxed = true)
+                callback(ConfigurationResult.NotConfigured) // Simulate NotConfigured result
+                internalNavigator
+            }
+        )
+
+        moleculeFlow(RecompositionClock.Immediate) {
+            presenter.present()
+        }.test {
+            awaitItem() // Consume initial state
+
+            // Verify sendPeriodicWorkRequest was NOT called again (it's called once on init if worker is enabled, but not due to this callback)
+            // To be precise, ensure no *additional* calls due to this specific callback.
+            // Since the setup might involve an initial call, we can't do `exactly = 0` without more complex setup.
+            // Instead, we rely on the fact that the Configured case *does* verify a call.
+            // A more robust way would be to count calls before and after, or use a spy on WorkManager with more detailed verification.
+            // For now, this implicitly tests that no *new* work request is scheduled due to NotConfigured.
+            // Let's ensure it's not called with a specific marker if possible, or simply that it's not called *again* if it was already.
+            // The initial setup does not call sendPeriodicWorkRequest, only the callback for Configured does.
+            verify(exactly = 0) { PeriodicWorkRequestManager.sendPeriodicWorkRequest(mockContext, currentInterval) }
+        }
+    }
+}


### PR DESCRIPTION
Add unit tests for UI presenters

This commit introduces unit tests for the following Circuit presenters:
- AboutAppPresenter
- AddNewRemoteAlertPresenter
- AlertCheckLogViewerPresenter
- AlertsListPresenter
- ConfigureNotificationMediumPresenter
- NotificationMediumListPresenter

The tests cover initial state, event handling, data loading, and interactions with dependencies, ensuring the business logic within these presenters is behaving as expected.