### PR TITLE
[FIX] Gradle warning `'jvmTarget: String' is deprecated.`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,10 +70,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
     buildFeatures {
         compose = true
         buildConfig = true
@@ -94,6 +90,13 @@ android {
             isIncludeAndroidResources = true
             isReturnDefaultValues = true
         }
+    }
+}
+
+kotlin {
+    // See https://kotlinlang.org/docs/gradle-compiler-options.html
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 


### PR DESCRIPTION
Fixes

```
> Configure project :app
w: file:///home/runner/work/android-remote-notify/android-remote-notify/app/build.gradle.kts:74:9: 'jvmTarget: String' is deprecated. Please migrate to the compilerOptions DSL. More details are here: https://kotl.in/u1r8ln
```