### PR TITLE
Fix Diffuse workflow to use signed APK filename

### DIFF
--- a/.github/workflows/diffuse.yml
+++ b/.github/workflows/diffuse.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Save base APK
         run: |
           mkdir -p /tmp/diffuse
-          cp app/build/outputs/apk/release/app-release-unsigned.apk /tmp/diffuse/base.apk
+          cp app/build/outputs/apk/release/app-release.apk /tmp/diffuse/base.apk
           echo "Base APK saved from ${{ github.base_ref }} branch"
 
       # Clean build directory before building PR APK
@@ -75,7 +75,7 @@ jobs:
         continue-on-error: true
         with:
           old-file-path: /tmp/diffuse/base.apk
-          new-file-path: app/build/outputs/apk/release/app-release-unsigned.apk
+          new-file-path: app/build/outputs/apk/release/app-release.apk
 
       # Post or update comment on PR
       - name: Find existing Diffuse comment
@@ -117,5 +117,5 @@ jobs:
         if: always()
         with:
           name: pr-apk
-          path: app/build/outputs/apk/release/app-release-unsigned.apk
+          path: app/build/outputs/apk/release/app-release.apk
           retention-days: 7


### PR DESCRIPTION
## Problem
The Diffuse workflow was failing because it was looking for `app-release-unsigned.apk`, but the build configuration produces a signed APK named `app-release.apk`.

## Root Cause
In `build.gradle.kts`, the release build type has signing configured, which produces a signed APK instead of an unsigned one.

## Solution
Updated all references in the Diffuse workflow from `app-release-unsigned.apk` to `app-release.apk`:
- Base APK save path
- Diffuse comparison new file path  
- PR APK upload artifact path

## Testing
This fix will be validated when the workflow runs on this PR itself.

## Related
Fixes the Diffuse workflow failures seen in recent PRs.