### PR TITLE
fix: ensure slider max storage value is always >= 10

### DIFF
--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlert.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlert.kt
@@ -144,10 +144,12 @@ class AddNewRemoteAlertPresenter
 
             /**
              * Round up to nearest 10 for slider max value.
+             * Ensure minimum value of 10 to accommodate slider range 1..max.
              */
             val storageSliderMax =
                 remember(availableStorage) {
-                    ((availableStorage + 9) / 10) * 10
+                    val rounded = ((availableStorage + 9) / 10) * 10
+                    maxOf(rounded, 10)  // Ensure at least 10 for valid range
                 }
 
             LaunchedImpressionEffect {

--- a/app/src/main/java/dev/hossain/remotenotify/ui/devportal/DeveloperPortalScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/devportal/DeveloperPortalScreen.kt
@@ -176,7 +176,10 @@ class DeveloperPortalPresenter
             // Get current device status
             val currentBatteryLevel = batteryMonitor.getBatteryLevel()
             val currentStorageGb = storageMonitor.getAvailableStorageInGB()
-            val maxStorageGb = remember { ((currentStorageGb + 9) / 10) * 10 } // Round up to nearest 10
+            val maxStorageGb = remember {
+                val rounded = ((currentStorageGb + 9) / 10) * 10
+                maxOf(rounded, 10)  // Ensure at least 10 for valid slider range
+            }
 
             // Get configured notification channels
             var configuredChannels by remember { mutableStateOf<Set<NotifierType>>(emptySet()) }


### PR DESCRIPTION
Fix crashes in both AddNewRemoteAlert and DeveloperPortalScreen where the storage slider valueRange becomes invalid (1..0) when available storage rounds down to 0 GB.
Now ensures storageSliderMax is always at least 10 using maxOf(), guaranteeing valid ranges: 1f..10f minimum.