### PR TITLE
Upgrade Metro to 1.0.0-RC2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ agp = "9.1.1"
 
 # Metro - A multiplatform dependency injection framework for Kotlin
 # https://zacsweers.github.io/metro/
-metro = "0.13.2"
+metro = "1.0.0-RC2"
 
 # https://github.com/slackhq/circuit/releases
 circuit = "0.33.1"


### PR DESCRIPTION
## Summary

Upgrade Metro DI framework to the latest release candidate version **1.0.0-RC2**.

## Changes

- `gradle/libs.versions.toml`: Metro `0.13.2` → `1.0.0-RC2`

## What's New in 1.0.0-RC2

This is the second release candidate for Metro 1.0, making its runtime APIs **API stable**.

### Improvements from RC1
- Fixes for K/N klib deserialization with `@HiddenFromObjC` annotations
- Better IDE support with hidden generated factories
- Improved implicit bound type cache collision handling
- Multiple bug fixes and stability improvements

## Testing

✅ Build verified: `./gradlew assembleDebug` successful in 51s

## Related Issues

Follows up on recent AGP 9.0 migration and Metro DSL syntax updates.