### PR TITLE
Add periodic battery and storage status checks

### DIFF
--- a/.github/workflows/diffuse.yml
+++ b/.github/workflows/diffuse.yml
@@ -79,7 +79,7 @@ jobs:
 
       # Post or update comment on PR
       - name: Find existing Diffuse comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         id: find_comment
         if: always()
         with:
@@ -87,7 +87,7 @@ jobs:
           body-includes: '📊 APK Size Analysis'
 
       - name: Create or update PR comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         if: always()
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/kover.yml
+++ b/.github/workflows/kover.yml
@@ -52,7 +52,7 @@ jobs:
       # Sticky Pull Request Comment
       # https://github.com/marocchino/sticky-pull-request-comment
       - name: Post coverage comment
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           message: |
             ## Code Coverage Report

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.10.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.10.0)" variant="all" version="8.10.0">
+<issues format="6" by="lint 9.2.0" type="baseline" client="gradle" dependencies="false" name="AGP (9.2.0)" variant="all" version="9.2.0">
 
     <issue
         id="Instantiatable"
@@ -13,13 +13,46 @@
     </issue>
 
     <issue
+        id="Instantiatable"
+        message="`MainActivity` must extend android.app.Activity"
+        errorLine1="            android:name=&quot;dev.hossain.remotenotify.MainActivity&quot;"
+        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="20"
+            column="27"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 31 (current min is 30): `dynamicDarkColorScheme`"
+        errorLine1="                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)"
+        errorLine2="                               ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/dev/hossain/remotenotify/theme/Theme.kt"
+            line="275"
+            column="32"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 31 (current min is 30): `dynamicLightColorScheme`"
+        errorLine1="                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)"
+        errorLine2="                                                                    ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/dev/hossain/remotenotify/theme/Theme.kt"
+            line="275"
+            column="69"/>
+    </issue>
+
+    <issue
         id="OldTargetApi"
         message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the `android.os.Build.VERSION_CODES` javadoc for details."
         errorLine1="        targetSdk = 35"
         errorLine2="        ~~~~~~~~~~~~~~">
         <location
             file="build.gradle.kts"
-            line="25"
+            line="28"
             column="9"/>
     </issue>
 
@@ -69,262 +102,339 @@
 
     <issue
         id="AndroidGradlePluginVersion"
-        message="A newer version of Gradle than 8.14.1 is available: 8.14.3"
-        errorLine1="distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip"
-        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        message="A newer version of Gradle than 9.4.1 is available: 9.6.1"
+        errorLine1="distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip"
+        errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/wrapper/gradle-wrapper.properties"
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/wrapper/gradle-wrapper.properties"
             line="3"
             column="17"/>
     </issue>
 
     <issue
         id="AndroidGradlePluginVersion"
-        message="A newer version of com.android.application than 8.10.0 is available: 8.11.1. (There is also a newer version of 8.10.𝑥 available, if upgrading to 8.11.1 is difficult: 8.10.1)"
-        errorLine1="agp = &quot;8.10.0&quot;"
-        errorLine2="      ~~~~~~~~">
+        message="A newer version of com.android.application than 9.2.0 is available: 9.2.1"
+        errorLine1="agp = &quot;9.2.0&quot;"
+        errorLine2="      ~~~~~~~">
         <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="10"
-            column="7"/>
-    </issue>
-
-    <issue
-        id="AndroidGradlePluginVersion"
-        message="A newer version of com.android.library than 8.10.0 is available: 8.11.1. (There is also a newer version of 8.10.𝑥 available, if upgrading to 8.11.1 is difficult: 8.10.1)"
-        errorLine1="agp = &quot;8.10.0&quot;"
-        errorLine2="      ~~~~~~~~">
-        <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
             line="10"
             column="7"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.compose:compose-bom than 2025.06.00 is available: 2025.07.00"
-        errorLine1="composeBom = &quot;2025.06.00&quot;"
+        message="A newer version of `compileSdk` than 36 is available: 37"
+        errorLine1="    compileSdk = 36"
+        errorLine2="    ~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="23"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.compose:compose-bom than 2026.04.01 is available: 2026.06.00"
+        errorLine1="composeBom = &quot;2026.04.01&quot;"
         errorLine2="             ~~~~~~~~~~~~">
         <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
             line="19"
             column="14"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.google.firebase:firebase-bom than 33.15.0 is available: 33.16.0"
-        errorLine1="firebaseBom = &quot;33.15.0&quot;"
+        message="A newer version of androidx.core:core-ktx than 1.18.0 is available: 1.19.0"
+        errorLine1="coreKtx = &quot;1.18.0&quot;"
+        errorLine2="          ~~~~~~~~">
+        <location
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="22"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of com.google.firebase:firebase-bom than 34.12.0 is available: 34.15.0"
+        errorLine1="firebaseBom = &quot;34.12.0&quot;"
         errorLine2="              ~~~~~~~~~">
         <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
             line="31"
             column="15"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.compose.ui:ui-text-google-fonts than 1.8.2 is available: 1.8.3"
-        errorLine1="googleFonts = &quot;1.8.2&quot;"
-        errorLine2="              ~~~~~~~">
+        message="A newer version of androidx.compose.ui:ui-text-google-fonts than 1.10.6 is available: 1.11.3"
+        errorLine1="googleFonts = &quot;1.10.6&quot;"
+        errorLine2="              ~~~~~~~~">
         <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
             line="34"
             column="15"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of io.mockk:mockk than 1.14.2 is available: 1.14.5"
-        errorLine1="mockk = &quot;1.14.2&quot;"
-        errorLine2="        ~~~~~~~~">
+        message="A newer version of com.google.gms.google-services than 4.4.4 is available: 4.5.0"
+        errorLine1="googleServices = &quot;4.4.4&quot;"
+        errorLine2="                 ~~~~~~~">
         <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="52"
-            column="9"/>
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="40"
+            column="18"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of org.jetbrains.kotlinx:kotlinx-serialization-json than 1.8.1 is available: 1.9.0"
-        errorLine1="kotlinxSerializationJson = &quot;1.8.1&quot;"
-        errorLine2="                           ~~~~~~~">
+        message="A newer version of androidx.lifecycle:lifecycle-runtime-ktx than 2.10.0 is available: 2.11.0"
+        errorLine1="lifecycleRuntimeKtx = &quot;2.10.0&quot;"
+        errorLine2="                      ~~~~~~~~">
         <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="59"
-            column="28"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.lifecycle:lifecycle-runtime-ktx than 2.9.1 is available: 2.9.2"
-        errorLine1="lifecycleRuntimeKtx = &quot;2.9.1&quot;"
-        errorLine2="                      ~~~~~~~">
-        <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="67"
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="83"
             column="23"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.navigation:navigation-compose than 2.9.0 is available: 2.9.2"
-        errorLine1="navigationCompose = &quot;2.9.0&quot;"
+        message="A newer version of androidx.navigation:navigation-compose than 2.9.7 is available: 2.9.8"
+        errorLine1="navigationCompose = &quot;2.9.7&quot;"
         errorLine2="                    ~~~~~~~">
         <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="75"
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="91"
             column="21"/>
     </issue>
 
     <issue
-        id="GradleDependency"
-        message="A newer version of com.squareup.okhttp3:logging-interceptor than 4.12.0 is available: 5.1.0"
-        errorLine1="okhttp = &quot;4.12.0&quot;"
+        id="NewerVersionAvailable"
+        message="A newer version of dev.zacsweers.metro than 1.0.0-RC4 is available: 1.3.0"
+        errorLine1="metro = &quot;1.0.0-RC4&quot;"
+        errorLine2="        ~~~~~~~~~~~">
+        <location
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="14"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.slack.circuit:circuit-codegen than 0.33.1 is available: 0.34.0"
+        errorLine1="circuit = &quot;0.33.1&quot;"
+        errorLine2="          ~~~~~~~~">
+        <location
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="17"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.slack.circuit:circuit-codegen-annotations than 0.33.1 is available: 0.34.0"
+        errorLine1="circuit = &quot;0.33.1&quot;"
+        errorLine2="          ~~~~~~~~">
+        <location
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="17"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.slack.circuit:circuit-foundation than 0.33.1 is available: 0.34.0"
+        errorLine1="circuit = &quot;0.33.1&quot;"
+        errorLine2="          ~~~~~~~~">
+        <location
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="17"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.slack.circuit:circuit-overlay than 0.33.1 is available: 0.34.0"
+        errorLine1="circuit = &quot;0.33.1&quot;"
+        errorLine2="          ~~~~~~~~">
+        <location
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="17"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.slack.circuit:circuitx-android than 0.33.1 is available: 0.34.0"
+        errorLine1="circuit = &quot;0.33.1&quot;"
+        errorLine2="          ~~~~~~~~">
+        <location
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="17"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.slack.circuit:circuitx-effects than 0.33.1 is available: 0.34.0"
+        errorLine1="circuit = &quot;0.33.1&quot;"
+        errorLine2="          ~~~~~~~~">
+        <location
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="17"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.slack.circuit:circuitx-gesture-navigation than 0.33.1 is available: 0.34.0"
+        errorLine1="circuit = &quot;0.33.1&quot;"
+        errorLine2="          ~~~~~~~~">
+        <location
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="17"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.slack.circuit:circuitx-overlays than 0.33.1 is available: 0.34.0"
+        errorLine1="circuit = &quot;0.33.1&quot;"
+        errorLine2="          ~~~~~~~~">
+        <location
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="17"
+            column="11"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.slack.lint.compose:compose-lint-checks than 1.4.2 is available: 1.5.2"
+        errorLine1="composeLintChecks = &quot;1.4.2&quot;"
+        errorLine2="                    ~~~~~~~">
+        <location
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="20"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-test than 1.10.2 is available: 1.11.0"
+        errorLine1="coroutinesTest = &quot;1.10.2&quot;"
+        errorLine2="                 ~~~~~~~~">
+        <location
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="23"
+            column="18"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlin.android than 2.3.20 is available: 2.4.0"
+        errorLine1="kotlin = &quot;2.3.20&quot;"
         errorLine2="         ~~~~~~~~">
         <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="79"
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="64"
             column="10"/>
     </issue>
 
     <issue
-        id="GradleDependency"
-        message="A newer version of com.squareup.okhttp3:mockwebserver than 4.12.0 is available: 5.1.0"
-        errorLine1="okhttp = &quot;4.12.0&quot;"
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlin.plugin.compose than 2.3.20 is available: 2.4.0"
+        errorLine1="kotlin = &quot;2.3.20&quot;"
         errorLine2="         ~~~~~~~~">
         <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="79"
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="64"
             column="10"/>
     </issue>
 
     <issue
-        id="GradleDependency"
-        message="A newer version of com.squareup.okhttp3:okhttp than 4.12.0 is available: 5.1.0"
-        errorLine1="okhttp = &quot;4.12.0&quot;"
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlin.plugin.parcelize than 2.3.20 is available: 2.4.0"
+        errorLine1="kotlin = &quot;2.3.20&quot;"
         errorLine2="         ~~~~~~~~">
         <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="79"
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="64"
             column="10"/>
     </issue>
 
     <issue
-        id="GradleDependency"
-        message="A newer version of androidx.room than 2.7.1 is available: 2.7.2"
-        errorLine1="roomDb = &quot;2.7.1&quot;"
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlin.plugin.serialization than 2.3.20 is available: 2.4.0"
+        errorLine1="kotlin = &quot;2.3.20&quot;"
+        errorLine2="         ~~~~~~~~">
+        <location
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="64"
+            column="10"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of io.mockk:mockk than 1.14.9 is available: 1.14.11"
+        errorLine1="mockk = &quot;1.14.9&quot;"
+        errorLine2="        ~~~~~~~~">
+        <location
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="68"
+            column="9"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of org.jmailen.kotlinter than 5.4.2 is available: 5.5.0"
+        errorLine1="kotlinter = &quot;5.4.2&quot;"
+        errorLine2="            ~~~~~~~">
+        <location
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="73"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="NewerVersionAvailable"
+        message="A newer version of com.squareup.okhttp3:logging-interceptor than 5.3.2 is available: 5.4.0"
+        errorLine1="okhttp = &quot;5.3.2&quot;"
         errorLine2="         ~~~~~~~">
         <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="84"
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="95"
             column="10"/>
     </issue>
 
     <issue
-        id="GradleDependency"
-        message="A newer version of androidx.room:room-compiler than 2.7.1 is available: 2.7.2"
-        errorLine1="roomDb = &quot;2.7.1&quot;"
+        id="NewerVersionAvailable"
+        message="A newer version of com.squareup.okhttp3:mockwebserver than 5.3.2 is available: 5.4.0"
+        errorLine1="okhttp = &quot;5.3.2&quot;"
         errorLine2="         ~~~~~~~">
         <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="84"
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="95"
             column="10"/>
     </issue>
 
     <issue
-        id="GradleDependency"
-        message="A newer version of androidx.room:room-ktx than 2.7.1 is available: 2.7.2"
-        errorLine1="roomDb = &quot;2.7.1&quot;"
+        id="NewerVersionAvailable"
+        message="A newer version of com.squareup.okhttp3:okhttp than 5.3.2 is available: 5.4.0"
+        errorLine1="okhttp = &quot;5.3.2&quot;"
         errorLine2="         ~~~~~~~">
         <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="84"
+            file="$HOME/dev/repos/android-apps/android-remote-notify/gradle/libs.versions.toml"
+            line="95"
             column="10"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.room:room-runtime than 2.7.1 is available: 2.7.2"
-        errorLine1="roomDb = &quot;2.7.1&quot;"
-        errorLine2="         ~~~~~~~">
-        <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="84"
-            column="10"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.room:room-testing than 2.7.1 is available: 2.7.2"
-        errorLine1="roomDb = &quot;2.7.1&quot;"
-        errorLine2="         ~~~~~~~">
-        <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="84"
-            column="10"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.work:work-runtime-ktx than 2.10.1 is available: 2.10.2"
-        errorLine1="workManager = &quot;2.10.1&quot;"
-        errorLine2="              ~~~~~~~~">
-        <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="92"
-            column="15"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.work:work-testing than 2.10.1 is available: 2.10.2"
-        errorLine1="workManager = &quot;2.10.1&quot;"
-        errorLine2="              ~~~~~~~~">
-        <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="92"
-            column="15"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of org.robolectric:robolectric than 4.14.1 is available: 4.15.1"
-        errorLine1="robolectric = { group = &quot;org.robolectric&quot;, name = &quot;robolectric&quot;, version = &quot;4.14.1&quot; }"
-        errorLine2="                                                                           ~~~~~~~~">
-        <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="179"
-            column="76"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of com.google.gms.google-services than 4.4.2 is available: 4.4.3"
-        errorLine1="google-services = { id = &quot;com.google.gms.google-services&quot;, version = &quot;4.4.2&quot; }"
-        errorLine2="                                                                     ~~~~~~~">
-        <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="238"
-            column="70"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of com.google.firebase.crashlytics than 3.0.3 is available: 3.0.4"
-        errorLine1="firebase-crashlytics = { id = &quot;com.google.firebase.crashlytics&quot;, version = &quot;3.0.3&quot; }"
-        errorLine2="                                                                           ~~~~~~~">
-        <location
-            file="$HOME/dev/repos/hk-projects/android-remote-notify/gradle/libs.versions.toml"
-            line="240"
-            column="76"/>
     </issue>
 
     <issue
         id="Typos"
         message="Did you mean &quot;CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA!&quot; instead of &quot;CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -335,7 +445,7 @@
         id="Typos"
         message="Did you mean &quot;DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA!&quot; instead of &quot;DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                        ^">
+        errorLine2="                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -346,7 +456,7 @@
         id="Typos"
         message="Did you mean &quot;GA!&quot; instead of &quot;GA1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                       ^">
+        errorLine2="                                                                                                                                                       ~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -357,7 +467,7 @@
         id="Typos"
         message="Did you mean &quot;GA!&quot; instead of &quot;GA1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                                               ^">
+        errorLine2="                                                                                                                                                                               ~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -368,7 +478,7 @@
         id="Typos"
         message="Did you mean &quot;GA!&quot; instead of &quot;GA1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                                                                       ^">
+        errorLine2="                                                                                                                                                                                                       ~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -379,7 +489,7 @@
         id="Typos"
         message="Did you mean &quot;GA!&quot; instead of &quot;GA1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                           ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                           ~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -390,7 +500,7 @@
         id="Typos"
         message="Did you mean &quot;GA!&quot; instead of &quot;GA1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                   ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                   ~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -401,7 +511,7 @@
         id="Typos"
         message="Did you mean &quot;GA!&quot; instead of &quot;GA1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                           ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                           ~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -412,7 +522,7 @@
         id="Typos"
         message="Did you mean &quot;GA!&quot; instead of &quot;GA1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   ~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -423,7 +533,7 @@
         id="Typos"
         message="Did you mean &quot;GA!&quot; instead of &quot;GA1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           ~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -434,7 +544,7 @@
         id="Typos"
         message="Did you mean &quot;GA!&quot; instead of &quot;GA1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   ~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -445,7 +555,7 @@
         id="Typos"
         message="Did you mean &quot;MAwGA!&quot; instead of &quot;MAwGA1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -456,7 +566,7 @@
         id="Typos"
         message="Did you mean &quot;NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA!&quot; instead of &quot;NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                                                                                                                                                                                ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -467,7 +577,7 @@
         id="Typos"
         message="Did you mean &quot;hZeTfHwqNvacKhp!&quot; instead of &quot;hZeTfHwqNvacKhp1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           ~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -478,7 +588,7 @@
         id="Typos"
         message="Did you mean &quot;mtKoOD!&quot; instead of &quot;mtKoOD1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             ~~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -489,7 +599,7 @@
         id="Typos"
         message="Did you mean &quot;pYTEWMBQGA!&quot; instead of &quot;pYTEWMBQGA1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                               ^">
+        errorLine2="                                                                                                               ~~~~~~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -500,7 +610,7 @@
         id="Typos"
         message="Did you mean &quot;pYTEWMBQGA!&quot; instead of &quot;pYTEWMBQGA1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                   ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                   ~~~~~~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -511,7 +621,7 @@
         id="Typos"
         message="Did you mean &quot;pYTEWMBQGA!&quot; instead of &quot;pYTEWMBQGA1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           ~~~~~~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -522,7 +632,7 @@
         id="Typos"
         message="Did you mean &quot;wNfdIjIz!&quot; instead of &quot;wNfdIjIz1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ~~~~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -533,7 +643,7 @@
         id="Typos"
         message="Did you mean &quot;xT!&quot; instead of &quot;xT1&quot;?"
         errorLine1="            MIIEqDCCA5CgAwIBAgIJANWFuGx90071MA0GCSqGSIb3DQEBBAUAMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTAeFw0wODA0MTUyMzM2NTZaFw0zNTA5MDEyMzM2NTZaMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbTCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBANbOLggKv+IxTdGNs8/TGFy0PTP6DHThvbbR24kT9ixcOd9W+EaBPWW+wPPKQmsHxajtWjmQwWfna8mZuSeJS48LIgAZlKkpFeVyxW0qMBujb8X8ETrWy550NaFtI6t9+u7hZeTfHwqNvacKhp1RbE6dBRGWynwMVX8XW8N1+UjFaq6GCJukT4qmpN2afb8sCjUigq0GuMwYXrFVee74bQgLHWGJwPmvmLHC69EH6kWr22ijx4OKXlSIx2xT1AsSHee70w5iDBiK4aph27yH3TxkXy9V89TDdexAcKk/cVHYNnDBapcavl7y0RiQ4biu8ymM8Ga/nmzhRKya6G0cGw8CAQOjgfwwgfkwHQYDVR0OBBYEFI0cxb6VTEM8YYY6FbBMvAPyT+CyMIHJBgNVHSMEgcEwgb6AFI0cxb6VTEM8YYY6FbBMvAPyT+CyoYGapIGXMIGUMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEQMA4GA1UEChMHQW5kcm9pZDEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDEiMCAGCSqGSIb3DQEJARYTYW5kcm9pZEBhbmRyb2lkLmNvbYIJANWFuGx90071MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADggEBABnTDPEF+3iSP0wNfdIjIz1AlnrPzgAIHVvXxunW7SBrDhEglQZBbKJEk5kT0mtKoOD1JMrSu1xuTKEBahWRbqHsXclaXjoBADb0kkjVEJu/Lh5hgYZnOjvlba8Ld7HCKePCVePoTJBdI4fvugnL8TsgK05aIskyY0hKI9L8KfqfGTl1lzOv2KoWD0KWwtAWPoGChZxmQ+nBli+gwYMzM1vAkP+aayLe0a1EQimlOalO762r0GXO0ks+UeXde2Z4e+8S/pf7pITEI/tP+MxJTALw9QUWEv9lKTk+jkbqxbsh8nfBUapfKqYn0eidpwq2AzVp3juYl7//fKnaPhJD9gs="
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  ~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="24"
@@ -544,7 +654,7 @@
         id="Typos"
         message="Did you mean &quot;GA!&quot; instead of &quot;GA1&quot;?"
         errorLine1="            MIIEQzCCAyugAwIBAgIJAMLgh0ZkSjCNMA0GCSqGSIb3DQEBBAUAMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDAeFw0wODA4MjEyMzEzMzRaFw0zNjAxMDcyMzEzMzRaMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAKtWLgDYO6IIrgqWbxJOKdoR8qtW0I9Y4sypEwPpt1TTcvZApxsdyxMJZ2JORland2qSGT2y5b+3JKkedxiLDmpHpDsz2WCbdxgxRczfey5YZnTJ4VZbH0xqWVW/8lGmPav5xVwnIiJS6HXk+BVKZF+JcWjAsb/GEuq/eFdpuzSqeYTcfi6idkyugwfYwXFU1+5fZKUaRKYCwkkFQVfcAs1fXA5V+++FGfvjJ/CxURaSxaBvGdGDhfXE28LWuT9ozCl5xw4Yq5OGazvV24mZVSoOO0yZ31j7kYvtwYK6NeADwbSxDdJEqO4k//0zOHKrUiGYXtqw/A0LFFtqoZKFjnkCAQOjgdkwgdYwHQYDVR0OBBYEFMd9jMIhF1Ylmn/Tgt9r45jk14alMIGmBgNVHSMEgZ4wgZuAFMd9jMIhF1Ylmn/Tgt9r45jk14aloXikdjB0MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLR29vZ2xlIEluYy4xEDAOBgNVBAsTB0FuZHJvaWQxEDAOBgNVBAMTB0FuZHJvaWSCCQDC4IdGZEowjTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBAUAA4IBAQBt0lLO74UwLDYKqs6Tm8/yzKkEu116FmH4rkaymUIE0P9KaMftGlMexFlaYjzmB2OxZyl6euNXEsQH8gjwyxCUKRJNexBiGcCEyj6z+a1fuHHvkiaai+KL8W1EyNmgjmyy8AW7P+LLlkR+ho5zEHatRbM/YAnqGcFh5iZBqpknHf1SKMXFh4dd239FJ1jWYfbMDMy3NS5CTMQ2XFI1MvcyUTdZPErjQfTbQe3aDQsQcafEQPD+nqActifKZ0Np0IS9L9kR/wbNvyz6ENwPiTrjV2KRkEjH78ZMcUQXg0L3BYHJ3lc69Vs5Ddf9uUGGMYldX3WfMBEmh/9iFBDAaTCK"
-        errorLine2="                                                                                                                                                                                   ^">
+        errorLine2="                                                                                                                                                                                   ~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="29"
@@ -555,7 +665,7 @@
         id="Typos"
         message="Did you mean &quot;GA!&quot; instead of &quot;GA1&quot;?"
         errorLine1="            MIIEQzCCAyugAwIBAgIJAMLgh0ZkSjCNMA0GCSqGSIb3DQEBBAUAMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDAeFw0wODA4MjEyMzEzMzRaFw0zNjAxMDcyMzEzMzRaMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAKtWLgDYO6IIrgqWbxJOKdoR8qtW0I9Y4sypEwPpt1TTcvZApxsdyxMJZ2JORland2qSGT2y5b+3JKkedxiLDmpHpDsz2WCbdxgxRczfey5YZnTJ4VZbH0xqWVW/8lGmPav5xVwnIiJS6HXk+BVKZF+JcWjAsb/GEuq/eFdpuzSqeYTcfi6idkyugwfYwXFU1+5fZKUaRKYCwkkFQVfcAs1fXA5V+++FGfvjJ/CxURaSxaBvGdGDhfXE28LWuT9ozCl5xw4Yq5OGazvV24mZVSoOO0yZ31j7kYvtwYK6NeADwbSxDdJEqO4k//0zOHKrUiGYXtqw/A0LFFtqoZKFjnkCAQOjgdkwgdYwHQYDVR0OBBYEFMd9jMIhF1Ylmn/Tgt9r45jk14alMIGmBgNVHSMEgZ4wgZuAFMd9jMIhF1Ylmn/Tgt9r45jk14aloXikdjB0MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLR29vZ2xlIEluYy4xEDAOBgNVBAsTB0FuZHJvaWQxEDAOBgNVBAMTB0FuZHJvaWSCCQDC4IdGZEowjTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBAUAA4IBAQBt0lLO74UwLDYKqs6Tm8/yzKkEu116FmH4rkaymUIE0P9KaMftGlMexFlaYjzmB2OxZyl6euNXEsQH8gjwyxCUKRJNexBiGcCEyj6z+a1fuHHvkiaai+KL8W1EyNmgjmyy8AW7P+LLlkR+ho5zEHatRbM/YAnqGcFh5iZBqpknHf1SKMXFh4dd239FJ1jWYfbMDMy3NS5CTMQ2XFI1MvcyUTdZPErjQfTbQe3aDQsQcafEQPD+nqActifKZ0Np0IS9L9kR/wbNvyz6ENwPiTrjV2KRkEjH78ZMcUQXg0L3BYHJ3lc69Vs5Ddf9uUGGMYldX3WfMBEmh/9iFBDAaTCK"
-        errorLine2="                                                                                                                                                                                                           ^">
+        errorLine2="                                                                                                                                                                                                           ~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="29"
@@ -566,7 +676,7 @@
         id="Typos"
         message="Did you mean &quot;GA!&quot; instead of &quot;GA1&quot;?"
         errorLine1="            MIIEQzCCAyugAwIBAgIJAMLgh0ZkSjCNMA0GCSqGSIb3DQEBBAUAMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDAeFw0wODA4MjEyMzEzMzRaFw0zNjAxMDcyMzEzMzRaMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAKtWLgDYO6IIrgqWbxJOKdoR8qtW0I9Y4sypEwPpt1TTcvZApxsdyxMJZ2JORland2qSGT2y5b+3JKkedxiLDmpHpDsz2WCbdxgxRczfey5YZnTJ4VZbH0xqWVW/8lGmPav5xVwnIiJS6HXk+BVKZF+JcWjAsb/GEuq/eFdpuzSqeYTcfi6idkyugwfYwXFU1+5fZKUaRKYCwkkFQVfcAs1fXA5V+++FGfvjJ/CxURaSxaBvGdGDhfXE28LWuT9ozCl5xw4Yq5OGazvV24mZVSoOO0yZ31j7kYvtwYK6NeADwbSxDdJEqO4k//0zOHKrUiGYXtqw/A0LFFtqoZKFjnkCAQOjgdkwgdYwHQYDVR0OBBYEFMd9jMIhF1Ylmn/Tgt9r45jk14alMIGmBgNVHSMEgZ4wgZuAFMd9jMIhF1Ylmn/Tgt9r45jk14aloXikdjB0MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLR29vZ2xlIEluYy4xEDAOBgNVBAsTB0FuZHJvaWQxEDAOBgNVBAMTB0FuZHJvaWSCCQDC4IdGZEowjTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBAUAA4IBAQBt0lLO74UwLDYKqs6Tm8/yzKkEu116FmH4rkaymUIE0P9KaMftGlMexFlaYjzmB2OxZyl6euNXEsQH8gjwyxCUKRJNexBiGcCEyj6z+a1fuHHvkiaai+KL8W1EyNmgjmyy8AW7P+LLlkR+ho5zEHatRbM/YAnqGcFh5iZBqpknHf1SKMXFh4dd239FJ1jWYfbMDMy3NS5CTMQ2XFI1MvcyUTdZPErjQfTbQe3aDQsQcafEQPD+nqActifKZ0Np0IS9L9kR/wbNvyz6ENwPiTrjV2KRkEjH78ZMcUQXg0L3BYHJ3lc69Vs5Ddf9uUGGMYldX3WfMBEmh/9iFBDAaTCK"
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                           ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                           ~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="29"
@@ -577,7 +687,7 @@
         id="Typos"
         message="Did you mean &quot;GA!&quot; instead of &quot;GA1&quot;?"
         errorLine1="            MIIEQzCCAyugAwIBAgIJAMLgh0ZkSjCNMA0GCSqGSIb3DQEBBAUAMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDAeFw0wODA4MjEyMzEzMzRaFw0zNjAxMDcyMzEzMzRaMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAKtWLgDYO6IIrgqWbxJOKdoR8qtW0I9Y4sypEwPpt1TTcvZApxsdyxMJZ2JORland2qSGT2y5b+3JKkedxiLDmpHpDsz2WCbdxgxRczfey5YZnTJ4VZbH0xqWVW/8lGmPav5xVwnIiJS6HXk+BVKZF+JcWjAsb/GEuq/eFdpuzSqeYTcfi6idkyugwfYwXFU1+5fZKUaRKYCwkkFQVfcAs1fXA5V+++FGfvjJ/CxURaSxaBvGdGDhfXE28LWuT9ozCl5xw4Yq5OGazvV24mZVSoOO0yZ31j7kYvtwYK6NeADwbSxDdJEqO4k//0zOHKrUiGYXtqw/A0LFFtqoZKFjnkCAQOjgdkwgdYwHQYDVR0OBBYEFMd9jMIhF1Ylmn/Tgt9r45jk14alMIGmBgNVHSMEgZ4wgZuAFMd9jMIhF1Ylmn/Tgt9r45jk14aloXikdjB0MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLR29vZ2xlIEluYy4xEDAOBgNVBAsTB0FuZHJvaWQxEDAOBgNVBAMTB0FuZHJvaWSCCQDC4IdGZEowjTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBAUAA4IBAQBt0lLO74UwLDYKqs6Tm8/yzKkEu116FmH4rkaymUIE0P9KaMftGlMexFlaYjzmB2OxZyl6euNXEsQH8gjwyxCUKRJNexBiGcCEyj6z+a1fuHHvkiaai+KL8W1EyNmgjmyy8AW7P+LLlkR+ho5zEHatRbM/YAnqGcFh5iZBqpknHf1SKMXFh4dd239FJ1jWYfbMDMy3NS5CTMQ2XFI1MvcyUTdZPErjQfTbQe3aDQsQcafEQPD+nqActifKZ0Np0IS9L9kR/wbNvyz6ENwPiTrjV2KRkEjH78ZMcUQXg0L3BYHJ3lc69Vs5Ddf9uUGGMYldX3WfMBEmh/9iFBDAaTCK"
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                   ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                   ~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="29"
@@ -588,7 +698,7 @@
         id="Typos"
         message="Did you mean &quot;MQswCQYDVQQGEwJVUzETMBEGA!&quot; instead of &quot;MQswCQYDVQQGEwJVUzETMBEGA1&quot;?"
         errorLine1="            MIIEQzCCAyugAwIBAgIJAMLgh0ZkSjCNMA0GCSqGSIb3DQEBBAUAMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDAeFw0wODA4MjEyMzEzMzRaFw0zNjAxMDcyMzEzMzRaMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAKtWLgDYO6IIrgqWbxJOKdoR8qtW0I9Y4sypEwPpt1TTcvZApxsdyxMJZ2JORland2qSGT2y5b+3JKkedxiLDmpHpDsz2WCbdxgxRczfey5YZnTJ4VZbH0xqWVW/8lGmPav5xVwnIiJS6HXk+BVKZF+JcWjAsb/GEuq/eFdpuzSqeYTcfi6idkyugwfYwXFU1+5fZKUaRKYCwkkFQVfcAs1fXA5V+++FGfvjJ/CxURaSxaBvGdGDhfXE28LWuT9ozCl5xw4Yq5OGazvV24mZVSoOO0yZ31j7kYvtwYK6NeADwbSxDdJEqO4k//0zOHKrUiGYXtqw/A0LFFtqoZKFjnkCAQOjgdkwgdYwHQYDVR0OBBYEFMd9jMIhF1Ylmn/Tgt9r45jk14alMIGmBgNVHSMEgZ4wgZuAFMd9jMIhF1Ylmn/Tgt9r45jk14aloXikdjB0MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLR29vZ2xlIEluYy4xEDAOBgNVBAsTB0FuZHJvaWQxEDAOBgNVBAMTB0FuZHJvaWSCCQDC4IdGZEowjTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBAUAA4IBAQBt0lLO74UwLDYKqs6Tm8/yzKkEu116FmH4rkaymUIE0P9KaMftGlMexFlaYjzmB2OxZyl6euNXEsQH8gjwyxCUKRJNexBiGcCEyj6z+a1fuHHvkiaai+KL8W1EyNmgjmyy8AW7P+LLlkR+ho5zEHatRbM/YAnqGcFh5iZBqpknHf1SKMXFh4dd239FJ1jWYfbMDMy3NS5CTMQ2XFI1MvcyUTdZPErjQfTbQe3aDQsQcafEQPD+nqActifKZ0Np0IS9L9kR/wbNvyz6ENwPiTrjV2KRkEjH78ZMcUQXg0L3BYHJ3lc69Vs5Ddf9uUGGMYldX3WfMBEmh/9iFBDAaTCK"
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="29"
@@ -599,7 +709,7 @@
         id="Typos"
         message="Did you mean &quot;XFI!&quot; instead of &quot;XFI1&quot;?"
         errorLine1="            MIIEQzCCAyugAwIBAgIJAMLgh0ZkSjCNMA0GCSqGSIb3DQEBBAUAMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDAeFw0wODA4MjEyMzEzMzRaFw0zNjAxMDcyMzEzMzRaMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAKtWLgDYO6IIrgqWbxJOKdoR8qtW0I9Y4sypEwPpt1TTcvZApxsdyxMJZ2JORland2qSGT2y5b+3JKkedxiLDmpHpDsz2WCbdxgxRczfey5YZnTJ4VZbH0xqWVW/8lGmPav5xVwnIiJS6HXk+BVKZF+JcWjAsb/GEuq/eFdpuzSqeYTcfi6idkyugwfYwXFU1+5fZKUaRKYCwkkFQVfcAs1fXA5V+++FGfvjJ/CxURaSxaBvGdGDhfXE28LWuT9ozCl5xw4Yq5OGazvV24mZVSoOO0yZ31j7kYvtwYK6NeADwbSxDdJEqO4k//0zOHKrUiGYXtqw/A0LFFtqoZKFjnkCAQOjgdkwgdYwHQYDVR0OBBYEFMd9jMIhF1Ylmn/Tgt9r45jk14alMIGmBgNVHSMEgZ4wgZuAFMd9jMIhF1Ylmn/Tgt9r45jk14aloXikdjB0MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLR29vZ2xlIEluYy4xEDAOBgNVBAsTB0FuZHJvaWQxEDAOBgNVBAMTB0FuZHJvaWSCCQDC4IdGZEowjTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBAUAA4IBAQBt0lLO74UwLDYKqs6Tm8/yzKkEu116FmH4rkaymUIE0P9KaMftGlMexFlaYjzmB2OxZyl6euNXEsQH8gjwyxCUKRJNexBiGcCEyj6z+a1fuHHvkiaai+KL8W1EyNmgjmyy8AW7P+LLlkR+ho5zEHatRbM/YAnqGcFh5iZBqpknHf1SKMXFh4dd239FJ1jWYfbMDMy3NS5CTMQ2XFI1MvcyUTdZPErjQfTbQe3aDQsQcafEQPD+nqActifKZ0Np0IS9L9kR/wbNvyz6ENwPiTrjV2KRkEjH78ZMcUQXg0L3BYHJ3lc69Vs5Ddf9uUGGMYldX3WfMBEmh/9iFBDAaTCK"
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        ~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="29"
@@ -610,7 +720,7 @@
         id="Typos"
         message="Did you mean &quot;gVmlldzEUMBIGA!&quot; instead of &quot;gVmlldzEUMBIGA1&quot;?"
         errorLine1="            MIIEQzCCAyugAwIBAgIJAMLgh0ZkSjCNMA0GCSqGSIb3DQEBBAUAMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDAeFw0wODA4MjEyMzEzMzRaFw0zNjAxMDcyMzEzMzRaMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAKtWLgDYO6IIrgqWbxJOKdoR8qtW0I9Y4sypEwPpt1TTcvZApxsdyxMJZ2JORland2qSGT2y5b+3JKkedxiLDmpHpDsz2WCbdxgxRczfey5YZnTJ4VZbH0xqWVW/8lGmPav5xVwnIiJS6HXk+BVKZF+JcWjAsb/GEuq/eFdpuzSqeYTcfi6idkyugwfYwXFU1+5fZKUaRKYCwkkFQVfcAs1fXA5V+++FGfvjJ/CxURaSxaBvGdGDhfXE28LWuT9ozCl5xw4Yq5OGazvV24mZVSoOO0yZ31j7kYvtwYK6NeADwbSxDdJEqO4k//0zOHKrUiGYXtqw/A0LFFtqoZKFjnkCAQOjgdkwgdYwHQYDVR0OBBYEFMd9jMIhF1Ylmn/Tgt9r45jk14alMIGmBgNVHSMEgZ4wgZuAFMd9jMIhF1Ylmn/Tgt9r45jk14aloXikdjB0MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLR29vZ2xlIEluYy4xEDAOBgNVBAsTB0FuZHJvaWQxEDAOBgNVBAMTB0FuZHJvaWSCCQDC4IdGZEowjTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBAUAA4IBAQBt0lLO74UwLDYKqs6Tm8/yzKkEu116FmH4rkaymUIE0P9KaMftGlMexFlaYjzmB2OxZyl6euNXEsQH8gjwyxCUKRJNexBiGcCEyj6z+a1fuHHvkiaai+KL8W1EyNmgjmyy8AW7P+LLlkR+ho5zEHatRbM/YAnqGcFh5iZBqpknHf1SKMXFh4dd239FJ1jWYfbMDMy3NS5CTMQ2XFI1MvcyUTdZPErjQfTbQe3aDQsQcafEQPD+nqActifKZ0Np0IS9L9kR/wbNvyz6ENwPiTrjV2KRkEjH78ZMcUQXg0L3BYHJ3lc69Vs5Ddf9uUGGMYldX3WfMBEmh/9iFBDAaTCK"
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           ~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="29"
@@ -621,7 +731,7 @@
         id="Typos"
         message="Did you mean &quot;iZBqpknHf!&quot; instead of &quot;iZBqpknHf1&quot;?"
         errorLine1="            MIIEQzCCAyugAwIBAgIJAMLgh0ZkSjCNMA0GCSqGSIb3DQEBBAUAMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDAeFw0wODA4MjEyMzEzMzRaFw0zNjAxMDcyMzEzMzRaMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAKtWLgDYO6IIrgqWbxJOKdoR8qtW0I9Y4sypEwPpt1TTcvZApxsdyxMJZ2JORland2qSGT2y5b+3JKkedxiLDmpHpDsz2WCbdxgxRczfey5YZnTJ4VZbH0xqWVW/8lGmPav5xVwnIiJS6HXk+BVKZF+JcWjAsb/GEuq/eFdpuzSqeYTcfi6idkyugwfYwXFU1+5fZKUaRKYCwkkFQVfcAs1fXA5V+++FGfvjJ/CxURaSxaBvGdGDhfXE28LWuT9ozCl5xw4Yq5OGazvV24mZVSoOO0yZ31j7kYvtwYK6NeADwbSxDdJEqO4k//0zOHKrUiGYXtqw/A0LFFtqoZKFjnkCAQOjgdkwgdYwHQYDVR0OBBYEFMd9jMIhF1Ylmn/Tgt9r45jk14alMIGmBgNVHSMEgZ4wgZuAFMd9jMIhF1Ylmn/Tgt9r45jk14aloXikdjB0MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLR29vZ2xlIEluYy4xEDAOBgNVBAsTB0FuZHJvaWQxEDAOBgNVBAMTB0FuZHJvaWSCCQDC4IdGZEowjTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBAUAA4IBAQBt0lLO74UwLDYKqs6Tm8/yzKkEu116FmH4rkaymUIE0P9KaMftGlMexFlaYjzmB2OxZyl6euNXEsQH8gjwyxCUKRJNexBiGcCEyj6z+a1fuHHvkiaai+KL8W1EyNmgjmyy8AW7P+LLlkR+ho5zEHatRbM/YAnqGcFh5iZBqpknHf1SKMXFh4dd239FJ1jWYfbMDMy3NS5CTMQ2XFI1MvcyUTdZPErjQfTbQe3aDQsQcafEQPD+nqActifKZ0Np0IS9L9kR/wbNvyz6ENwPiTrjV2KRkEjH78ZMcUQXg0L3BYHJ3lc69Vs5Ddf9uUGGMYldX3WfMBEmh/9iFBDAaTCK"
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             ~~~~~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="29"
@@ -632,7 +742,7 @@
         id="Typos"
         message="Did you mean &quot;idkyugwfYwXFU!&quot; instead of &quot;idkyugwfYwXFU1&quot;?"
         errorLine1="            MIIEQzCCAyugAwIBAgIJAMLgh0ZkSjCNMA0GCSqGSIb3DQEBBAUAMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDAeFw0wODA4MjEyMzEzMzRaFw0zNjAxMDcyMzEzMzRaMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAKtWLgDYO6IIrgqWbxJOKdoR8qtW0I9Y4sypEwPpt1TTcvZApxsdyxMJZ2JORland2qSGT2y5b+3JKkedxiLDmpHpDsz2WCbdxgxRczfey5YZnTJ4VZbH0xqWVW/8lGmPav5xVwnIiJS6HXk+BVKZF+JcWjAsb/GEuq/eFdpuzSqeYTcfi6idkyugwfYwXFU1+5fZKUaRKYCwkkFQVfcAs1fXA5V+++FGfvjJ/CxURaSxaBvGdGDhfXE28LWuT9ozCl5xw4Yq5OGazvV24mZVSoOO0yZ31j7kYvtwYK6NeADwbSxDdJEqO4k//0zOHKrUiGYXtqw/A0LFFtqoZKFjnkCAQOjgdkwgdYwHQYDVR0OBBYEFMd9jMIhF1Ylmn/Tgt9r45jk14alMIGmBgNVHSMEgZ4wgZuAFMd9jMIhF1Ylmn/Tgt9r45jk14aloXikdjB0MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLR29vZ2xlIEluYy4xEDAOBgNVBAsTB0FuZHJvaWQxEDAOBgNVBAMTB0FuZHJvaWSCCQDC4IdGZEowjTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBAUAA4IBAQBt0lLO74UwLDYKqs6Tm8/yzKkEu116FmH4rkaymUIE0P9KaMftGlMexFlaYjzmB2OxZyl6euNXEsQH8gjwyxCUKRJNexBiGcCEyj6z+a1fuHHvkiaai+KL8W1EyNmgjmyy8AW7P+LLlkR+ho5zEHatRbM/YAnqGcFh5iZBqpknHf1SKMXFh4dd239FJ1jWYfbMDMy3NS5CTMQ2XFI1MvcyUTdZPErjQfTbQe3aDQsQcafEQPD+nqActifKZ0Np0IS9L9kR/wbNvyz6ENwPiTrjV2KRkEjH78ZMcUQXg0L3BYHJ3lc69Vs5Ddf9uUGGMYldX3WfMBEmh/9iFBDAaTCK"
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   ~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="29"
@@ -643,7 +753,7 @@
         id="Typos"
         message="Did you mean &quot;jMIhF!&quot; instead of &quot;jMIhF1&quot;?"
         errorLine1="            MIIEQzCCAyugAwIBAgIJAMLgh0ZkSjCNMA0GCSqGSIb3DQEBBAUAMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDAeFw0wODA4MjEyMzEzMzRaFw0zNjAxMDcyMzEzMzRaMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAKtWLgDYO6IIrgqWbxJOKdoR8qtW0I9Y4sypEwPpt1TTcvZApxsdyxMJZ2JORland2qSGT2y5b+3JKkedxiLDmpHpDsz2WCbdxgxRczfey5YZnTJ4VZbH0xqWVW/8lGmPav5xVwnIiJS6HXk+BVKZF+JcWjAsb/GEuq/eFdpuzSqeYTcfi6idkyugwfYwXFU1+5fZKUaRKYCwkkFQVfcAs1fXA5V+++FGfvjJ/CxURaSxaBvGdGDhfXE28LWuT9ozCl5xw4Yq5OGazvV24mZVSoOO0yZ31j7kYvtwYK6NeADwbSxDdJEqO4k//0zOHKrUiGYXtqw/A0LFFtqoZKFjnkCAQOjgdkwgdYwHQYDVR0OBBYEFMd9jMIhF1Ylmn/Tgt9r45jk14alMIGmBgNVHSMEgZ4wgZuAFMd9jMIhF1Ylmn/Tgt9r45jk14aloXikdjB0MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLR29vZ2xlIEluYy4xEDAOBgNVBAsTB0FuZHJvaWQxEDAOBgNVBAMTB0FuZHJvaWSCCQDC4IdGZEowjTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBAUAA4IBAQBt0lLO74UwLDYKqs6Tm8/yzKkEu116FmH4rkaymUIE0P9KaMftGlMexFlaYjzmB2OxZyl6euNXEsQH8gjwyxCUKRJNexBiGcCEyj6z+a1fuHHvkiaai+KL8W1EyNmgjmyy8AW7P+LLlkR+ho5zEHatRbM/YAnqGcFh5iZBqpknHf1SKMXFh4dd239FJ1jWYfbMDMy3NS5CTMQ2XFI1MvcyUTdZPErjQfTbQe3aDQsQcafEQPD+nqActifKZ0Np0IS9L9kR/wbNvyz6ENwPiTrjV2KRkEjH78ZMcUQXg0L3BYHJ3lc69Vs5Ddf9uUGGMYldX3WfMBEmh/9iFBDAaTCK"
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="29"
@@ -654,7 +764,7 @@
         id="Typos"
         message="Did you mean &quot;jMIhF!&quot; instead of &quot;jMIhF1&quot;?"
         errorLine1="            MIIEQzCCAyugAwIBAgIJAMLgh0ZkSjCNMA0GCSqGSIb3DQEBBAUAMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDAeFw0wODA4MjEyMzEzMzRaFw0zNjAxMDcyMzEzMzRaMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAKtWLgDYO6IIrgqWbxJOKdoR8qtW0I9Y4sypEwPpt1TTcvZApxsdyxMJZ2JORland2qSGT2y5b+3JKkedxiLDmpHpDsz2WCbdxgxRczfey5YZnTJ4VZbH0xqWVW/8lGmPav5xVwnIiJS6HXk+BVKZF+JcWjAsb/GEuq/eFdpuzSqeYTcfi6idkyugwfYwXFU1+5fZKUaRKYCwkkFQVfcAs1fXA5V+++FGfvjJ/CxURaSxaBvGdGDhfXE28LWuT9ozCl5xw4Yq5OGazvV24mZVSoOO0yZ31j7kYvtwYK6NeADwbSxDdJEqO4k//0zOHKrUiGYXtqw/A0LFFtqoZKFjnkCAQOjgdkwgdYwHQYDVR0OBBYEFMd9jMIhF1Ylmn/Tgt9r45jk14alMIGmBgNVHSMEgZ4wgZuAFMd9jMIhF1Ylmn/Tgt9r45jk14aloXikdjB0MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLR29vZ2xlIEluYy4xEDAOBgNVBAsTB0FuZHJvaWQxEDAOBgNVBAMTB0FuZHJvaWSCCQDC4IdGZEowjTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBAUAA4IBAQBt0lLO74UwLDYKqs6Tm8/yzKkEu116FmH4rkaymUIE0P9KaMftGlMexFlaYjzmB2OxZyl6euNXEsQH8gjwyxCUKRJNexBiGcCEyj6z+a1fuHHvkiaai+KL8W1EyNmgjmyy8AW7P+LLlkR+ho5zEHatRbM/YAnqGcFh5iZBqpknHf1SKMXFh4dd239FJ1jWYfbMDMy3NS5CTMQ2XFI1MvcyUTdZPErjQfTbQe3aDQsQcafEQPD+nqActifKZ0Np0IS9L9kR/wbNvyz6ENwPiTrjV2KRkEjH78ZMcUQXg0L3BYHJ3lc69Vs5Ddf9uUGGMYldX3WfMBEmh/9iFBDAaTCK"
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    ~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="29"
@@ -665,7 +775,7 @@
         id="Typos"
         message="Did you mean &quot;pYTEWMBQGA!&quot; instead of &quot;pYTEWMBQGA1&quot;?"
         errorLine1="            MIIEQzCCAyugAwIBAgIJAMLgh0ZkSjCNMA0GCSqGSIb3DQEBBAUAMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDAeFw0wODA4MjEyMzEzMzRaFw0zNjAxMDcyMzEzMzRaMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAKtWLgDYO6IIrgqWbxJOKdoR8qtW0I9Y4sypEwPpt1TTcvZApxsdyxMJZ2JORland2qSGT2y5b+3JKkedxiLDmpHpDsz2WCbdxgxRczfey5YZnTJ4VZbH0xqWVW/8lGmPav5xVwnIiJS6HXk+BVKZF+JcWjAsb/GEuq/eFdpuzSqeYTcfi6idkyugwfYwXFU1+5fZKUaRKYCwkkFQVfcAs1fXA5V+++FGfvjJ/CxURaSxaBvGdGDhfXE28LWuT9ozCl5xw4Yq5OGazvV24mZVSoOO0yZ31j7kYvtwYK6NeADwbSxDdJEqO4k//0zOHKrUiGYXtqw/A0LFFtqoZKFjnkCAQOjgdkwgdYwHQYDVR0OBBYEFMd9jMIhF1Ylmn/Tgt9r45jk14alMIGmBgNVHSMEgZ4wgZuAFMd9jMIhF1Ylmn/Tgt9r45jk14aloXikdjB0MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLR29vZ2xlIEluYy4xEDAOBgNVBAsTB0FuZHJvaWQxEDAOBgNVBAMTB0FuZHJvaWSCCQDC4IdGZEowjTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBAUAA4IBAQBt0lLO74UwLDYKqs6Tm8/yzKkEu116FmH4rkaymUIE0P9KaMftGlMexFlaYjzmB2OxZyl6euNXEsQH8gjwyxCUKRJNexBiGcCEyj6z+a1fuHHvkiaai+KL8W1EyNmgjmyy8AW7P+LLlkR+ho5zEHatRbM/YAnqGcFh5iZBqpknHf1SKMXFh4dd239FJ1jWYfbMDMy3NS5CTMQ2XFI1MvcyUTdZPErjQfTbQe3aDQsQcafEQPD+nqActifKZ0Np0IS9L9kR/wbNvyz6ENwPiTrjV2KRkEjH78ZMcUQXg0L3BYHJ3lc69Vs5Ddf9uUGGMYldX3WfMBEmh/9iFBDAaTCK"
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               ~~~~~~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="29"
@@ -676,7 +786,7 @@
         id="Typos"
         message="Did you mean &quot;sypEwPpt!&quot; instead of &quot;sypEwPpt1&quot;?"
         errorLine1="            MIIEQzCCAyugAwIBAgIJAMLgh0ZkSjCNMA0GCSqGSIb3DQEBBAUAMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDAeFw0wODA4MjEyMzEzMzRaFw0zNjAxMDcyMzEzMzRaMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAKtWLgDYO6IIrgqWbxJOKdoR8qtW0I9Y4sypEwPpt1TTcvZApxsdyxMJZ2JORland2qSGT2y5b+3JKkedxiLDmpHpDsz2WCbdxgxRczfey5YZnTJ4VZbH0xqWVW/8lGmPav5xVwnIiJS6HXk+BVKZF+JcWjAsb/GEuq/eFdpuzSqeYTcfi6idkyugwfYwXFU1+5fZKUaRKYCwkkFQVfcAs1fXA5V+++FGfvjJ/CxURaSxaBvGdGDhfXE28LWuT9ozCl5xw4Yq5OGazvV24mZVSoOO0yZ31j7kYvtwYK6NeADwbSxDdJEqO4k//0zOHKrUiGYXtqw/A0LFFtqoZKFjnkCAQOjgdkwgdYwHQYDVR0OBBYEFMd9jMIhF1Ylmn/Tgt9r45jk14alMIGmBgNVHSMEgZ4wgZuAFMd9jMIhF1Ylmn/Tgt9r45jk14aloXikdjB0MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLR29vZ2xlIEluYy4xEDAOBgNVBAsTB0FuZHJvaWQxEDAOBgNVBAMTB0FuZHJvaWSCCQDC4IdGZEowjTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBAUAA4IBAQBt0lLO74UwLDYKqs6Tm8/yzKkEu116FmH4rkaymUIE0P9KaMftGlMexFlaYjzmB2OxZyl6euNXEsQH8gjwyxCUKRJNexBiGcCEyj6z+a1fuHHvkiaai+KL8W1EyNmgjmyy8AW7P+LLlkR+ho5zEHatRbM/YAnqGcFh5iZBqpknHf1SKMXFh4dd239FJ1jWYfbMDMy3NS5CTMQ2XFI1MvcyUTdZPErjQfTbQe3aDQsQcafEQPD+nqActifKZ0Np0IS9L9kR/wbNvyz6ENwPiTrjV2KRkEjH78ZMcUQXg0L3BYHJ3lc69Vs5Ddf9uUGGMYldX3WfMBEmh/9iFBDAaTCK"
-        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 ~~~~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="29"
@@ -687,7 +797,7 @@
         id="Typos"
         message="Did you mean &quot;ybmlhMRYwFAYDVQQHEw!&quot; instead of &quot;ybmlhMRYwFAYDVQQHEw1&quot;?"
         errorLine1="            MIIEQzCCAyugAwIBAgIJAMLgh0ZkSjCNMA0GCSqGSIb3DQEBBAUAMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDAeFw0wODA4MjEyMzEzMzRaFw0zNjAxMDcyMzEzMzRaMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAKtWLgDYO6IIrgqWbxJOKdoR8qtW0I9Y4sypEwPpt1TTcvZApxsdyxMJZ2JORland2qSGT2y5b+3JKkedxiLDmpHpDsz2WCbdxgxRczfey5YZnTJ4VZbH0xqWVW/8lGmPav5xVwnIiJS6HXk+BVKZF+JcWjAsb/GEuq/eFdpuzSqeYTcfi6idkyugwfYwXFU1+5fZKUaRKYCwkkFQVfcAs1fXA5V+++FGfvjJ/CxURaSxaBvGdGDhfXE28LWuT9ozCl5xw4Yq5OGazvV24mZVSoOO0yZ31j7kYvtwYK6NeADwbSxDdJEqO4k//0zOHKrUiGYXtqw/A0LFFtqoZKFjnkCAQOjgdkwgdYwHQYDVR0OBBYEFMd9jMIhF1Ylmn/Tgt9r45jk14alMIGmBgNVHSMEgZ4wgZuAFMd9jMIhF1Ylmn/Tgt9r45jk14aloXikdjB0MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLR29vZ2xlIEluYy4xEDAOBgNVBAsTB0FuZHJvaWQxEDAOBgNVBAMTB0FuZHJvaWSCCQDC4IdGZEowjTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBAUAA4IBAQBt0lLO74UwLDYKqs6Tm8/yzKkEu116FmH4rkaymUIE0P9KaMftGlMexFlaYjzmB2OxZyl6euNXEsQH8gjwyxCUKRJNexBiGcCEyj6z+a1fuHHvkiaai+KL8W1EyNmgjmyy8AW7P+LLlkR+ho5zEHatRbM/YAnqGcFh5iZBqpknHf1SKMXFh4dd239FJ1jWYfbMDMy3NS5CTMQ2XFI1MvcyUTdZPErjQfTbQe3aDQsQcafEQPD+nqActifKZ0Np0IS9L9kR/wbNvyz6ENwPiTrjV2KRkEjH78ZMcUQXg0L3BYHJ3lc69Vs5Ddf9uUGGMYldX3WfMBEmh/9iFBDAaTCK"
-        errorLine2="                                                                                                           ^">
+        errorLine2="                                                                                                           ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="29"
@@ -698,7 +808,7 @@
         id="Typos"
         message="Did you mean &quot;ybmlhMRYwFAYDVQQHEw!&quot; instead of &quot;ybmlhMRYwFAYDVQQHEw1&quot;?"
         errorLine1="            MIIEQzCCAyugAwIBAgIJAMLgh0ZkSjCNMA0GCSqGSIb3DQEBBAUAMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDAeFw0wODA4MjEyMzEzMzRaFw0zNjAxMDcyMzEzMzRaMHQxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1Nb3VudGFpbiBWaWV3MRQwEgYDVQQKEwtHb29nbGUgSW5jLjEQMA4GA1UECxMHQW5kcm9pZDEQMA4GA1UEAxMHQW5kcm9pZDCCASAwDQYJKoZIhvcNAQEBBQADggENADCCAQgCggEBAKtWLgDYO6IIrgqWbxJOKdoR8qtW0I9Y4sypEwPpt1TTcvZApxsdyxMJZ2JORland2qSGT2y5b+3JKkedxiLDmpHpDsz2WCbdxgxRczfey5YZnTJ4VZbH0xqWVW/8lGmPav5xVwnIiJS6HXk+BVKZF+JcWjAsb/GEuq/eFdpuzSqeYTcfi6idkyugwfYwXFU1+5fZKUaRKYCwkkFQVfcAs1fXA5V+++FGfvjJ/CxURaSxaBvGdGDhfXE28LWuT9ozCl5xw4Yq5OGazvV24mZVSoOO0yZ31j7kYvtwYK6NeADwbSxDdJEqO4k//0zOHKrUiGYXtqw/A0LFFtqoZKFjnkCAQOjgdkwgdYwHQYDVR0OBBYEFMd9jMIhF1Ylmn/Tgt9r45jk14alMIGmBgNVHSMEgZ4wgZuAFMd9jMIhF1Ylmn/Tgt9r45jk14aloXikdjB0MQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLR29vZ2xlIEluYy4xEDAOBgNVBAsTB0FuZHJvaWQxEDAOBgNVBAMTB0FuZHJvaWSCCQDC4IdGZEowjTAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBAUAA4IBAQBt0lLO74UwLDYKqs6Tm8/yzKkEu116FmH4rkaymUIE0P9KaMftGlMexFlaYjzmB2OxZyl6euNXEsQH8gjwyxCUKRJNexBiGcCEyj6z+a1fuHHvkiaai+KL8W1EyNmgjmyy8AW7P+LLlkR+ho5zEHatRbM/YAnqGcFh5iZBqpknHf1SKMXFh4dd239FJ1jWYfbMDMy3NS5CTMQ2XFI1MvcyUTdZPErjQfTbQe3aDQsQcafEQPD+nqActifKZ0Np0IS9L9kR/wbNvyz6ENwPiTrjV2KRkEjH78ZMcUQXg0L3BYHJ3lc69Vs5Ddf9uUGGMYldX3WfMBEmh/9iFBDAaTCK"
-        errorLine2="                                                                                                                                                                                                                                                                                                                   ^">
+        errorLine2="                                                                                                                                                                                                                                                                                                                   ~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values-v23/font_certs.xml"
             line="29"
@@ -717,138 +827,6 @@
         message="This folder configuration (`v23`) is unnecessary; `minSdkVersion` is 30. Merge all the resources in this folder into `values`.">
         <location
             file="src/main/res/values-v23"/>
-    </issue>
-
-    <issue
-        id="VectorPath"
-        message="Very long vector path (973 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        errorLine1="      android:pathData=&quot;m343.4,149.13c2.79,-0.43 5.32,-0.3 7.93,0.94c1.59,0.76 2.6,2.1 3.07,3.76c2.21,7.8 -7.95,20.83 -11.94,27.42c15.49,9.36 25.42,21.58 30.49,39.05c7.8,0.25 22.7,-1.98 28.82,3.15c2.27,1.9 2.32,3.65 2.59,6.53c0.83,8.99 0.15,18.47 0.2,27.52l0.19,60.4l0.12,63.71c0.06,11.94 0.9,26.2 -0.25,37.91c-0.22,2.28 -1.06,3.81 -2.6,5.49c-1.75,1.9 -6.03,2.06 -8.53,2.21c-5.46,0.33 -11.09,-0.03 -16.56,-0.1l-29.19,-0.24l-92.98,0.14c-7.68,0.08 -18.65,1.27 -25.92,-0.6c-3.01,-0.77 -7.09,-2.84 -8.45,-5.84c-1.11,-2.47 -1.31,-6.65 -1.38,-9.37c-0.28,-11.57 0.09,-23.24 0.16,-34.82l0.2,-58.29c0.17,-27.8 -0.45,-55.68 0.23,-83.48c0.05,-2.21 0.12,-8.19 1.43,-9.91c5.5,-7.18 23.93,-4.56 32.21,-4.41c0.09,-0.73 0.2,-1.47 0.32,-2.2c2.77,-16.17 13.64,-27.33 26.45,-36.49c-3.13,-6.6 -13.86,-17.9 -12.19,-25.11c0.54,-2.3 2.04,-4.25 4.04,-5.48c2.26,-1.38 4.99,-1.78 7.55,-1.11c6.65,1.76 8.95,9.86 11.8,15.21c1.72,3.23 3.62,6.38 5.47,9.53c9.97,-2.03 19.59,-1.95 29.56,0.04c3.84,-7.21 10.22,-21.36 17.17,-25.56z&quot;"
-        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/drawable/app_icon_art.xml"
-            line="24"
-            column="25"/>
-    </issue>
-
-    <issue
-        id="VectorPath"
-        message="Very long vector path (2585 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        errorLine1="      android:pathData=&quot;M477.6,93.87L409.6,93.87L409.6,33.81C409.6,15.16 394.44,0 375.79,0L153.28,0C134.63,0 119.47,15.16 119.47,33.81L119.47,76.8C114.75,76.8 110.93,80.61 110.93,85.33L110.93,93.87C110.93,98.58 114.75,102.4 119.47,102.4L119.47,110.93C114.75,110.93 110.93,114.75 110.93,119.46L110.93,128C110.93,132.72 114.75,136.53 119.47,136.53L119.47,179.2L34.4,179.2C15.44,179.2 0,194.64 0,213.6L0,332.54C0,351.5 15.44,366.93 34.4,366.93L119.47,366.93L119.47,478.19C119.47,496.84 134.63,512 153.28,512L375.79,512C394.44,512 409.6,496.84 409.6,478.19L409.6,281.6L477.6,281.6C496.57,281.6 512,266.16 512,247.2L512,128.26C512,109.3 496.57,93.87 477.6,93.87ZM136.53,33.81C136.53,24.58 144.04,17.07 153.27,17.07L375.79,17.07C385.02,17.07 392.53,24.58 392.53,33.81L392.53,51.2L136.53,51.2L136.53,33.81L136.53,33.81ZM68.27,332.8C63.55,332.8 59.73,328.99 59.73,324.27L59.73,264.53C59.73,259.82 63.55,256 68.27,256L76.8,256L76.8,247.47C76.8,228.64 92.11,213.34 110.93,213.34C129.76,213.34 145.07,228.64 145.07,247.47L145.07,256L153.6,256C158.32,256 162.13,259.81 162.13,264.53L162.13,324.27C162.13,328.98 158.32,332.8 153.6,332.8L68.27,332.8L68.27,332.8ZM242.19,494.93L153.28,494.93C144.04,494.93 136.53,487.42 136.53,478.19L136.53,443.73L242.19,443.73C235.03,450 230.4,459.09 230.4,469.33C230.4,479.57 235.02,488.67 242.19,494.93ZM264.53,486.4C255.13,486.4 247.47,478.75 247.47,469.33C247.47,459.92 255.13,452.27 264.53,452.27C273.95,452.27 281.6,459.92 281.6,469.33C281.6,478.75 273.95,486.4 264.53,486.4ZM392.53,478.19C392.53,487.42 385.02,494.93 375.79,494.93L286.87,494.93C294.04,488.67 298.67,479.57 298.67,469.33C298.67,459.09 294.04,450 286.87,443.73L392.53,443.73L392.53,478.19L392.53,478.19ZM392.53,426.67L136.53,426.67L136.53,366.93L147.56,366.93L162.47,404.23C163.77,407.48 166.91,409.6 170.4,409.6C173.89,409.6 177.02,407.48 178.33,404.23L193.45,366.4C209.58,363.57 221.87,349.46 221.87,332.54L221.87,213.6C221.87,194.64 206.44,179.2 187.47,179.2L136.53,179.2L136.53,68.27L392.53,68.27L392.53,93.87L324.53,93.87C305.57,93.87 290.13,109.3 290.13,128.26L290.13,247.2C290.13,264.13 302.43,278.24 318.55,281.07L333.68,318.9C334.98,322.14 338.11,324.27 341.6,324.27C345.1,324.27 348.23,322.14 349.52,318.9L364.44,281.6L392.53,281.6L392.53,426.67L392.53,426.67ZM438.08,238.93L416.66,238.87L416.21,238.93L365.73,238.93C347.58,238.93 332.8,223.04 332.8,203.5C332.8,191.51 338.63,180.25 347.91,173.76C352.14,160.91 364.38,152.33 377.22,153.32C385.01,142.83 396.89,136.53 409.48,136.53C430.05,136.53 447.29,153.06 450.33,174.48C461.64,179.67 469.33,191.73 469.33,205.35C469.33,223.87 455.32,238.93 438.08,238.93Z&quot;"
-        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/drawable-night/app_icon_v3.xml"
-            line="16"
-            column="25"/>
-    </issue>
-
-    <issue
-        id="VectorPath"
-        message="Very long vector path (2585 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        errorLine1="      android:pathData=&quot;M477.6,93.87L409.6,93.87L409.6,33.81C409.6,15.16 394.44,0 375.79,0L153.28,0C134.63,0 119.47,15.16 119.47,33.81L119.47,76.8C114.75,76.8 110.93,80.61 110.93,85.33L110.93,93.87C110.93,98.58 114.75,102.4 119.47,102.4L119.47,110.93C114.75,110.93 110.93,114.75 110.93,119.46L110.93,128C110.93,132.72 114.75,136.53 119.47,136.53L119.47,179.2L34.4,179.2C15.44,179.2 0,194.64 0,213.6L0,332.54C0,351.5 15.44,366.93 34.4,366.93L119.47,366.93L119.47,478.19C119.47,496.84 134.63,512 153.28,512L375.79,512C394.44,512 409.6,496.84 409.6,478.19L409.6,281.6L477.6,281.6C496.57,281.6 512,266.16 512,247.2L512,128.26C512,109.3 496.57,93.87 477.6,93.87ZM136.53,33.81C136.53,24.58 144.04,17.07 153.27,17.07L375.79,17.07C385.02,17.07 392.53,24.58 392.53,33.81L392.53,51.2L136.53,51.2L136.53,33.81L136.53,33.81ZM68.27,332.8C63.55,332.8 59.73,328.99 59.73,324.27L59.73,264.53C59.73,259.82 63.55,256 68.27,256L76.8,256L76.8,247.47C76.8,228.64 92.11,213.34 110.93,213.34C129.76,213.34 145.07,228.64 145.07,247.47L145.07,256L153.6,256C158.32,256 162.13,259.81 162.13,264.53L162.13,324.27C162.13,328.98 158.32,332.8 153.6,332.8L68.27,332.8L68.27,332.8ZM242.19,494.93L153.28,494.93C144.04,494.93 136.53,487.42 136.53,478.19L136.53,443.73L242.19,443.73C235.03,450 230.4,459.09 230.4,469.33C230.4,479.57 235.02,488.67 242.19,494.93ZM264.53,486.4C255.13,486.4 247.47,478.75 247.47,469.33C247.47,459.92 255.13,452.27 264.53,452.27C273.95,452.27 281.6,459.92 281.6,469.33C281.6,478.75 273.95,486.4 264.53,486.4ZM392.53,478.19C392.53,487.42 385.02,494.93 375.79,494.93L286.87,494.93C294.04,488.67 298.67,479.57 298.67,469.33C298.67,459.09 294.04,450 286.87,443.73L392.53,443.73L392.53,478.19L392.53,478.19ZM392.53,426.67L136.53,426.67L136.53,366.93L147.56,366.93L162.47,404.23C163.77,407.48 166.91,409.6 170.4,409.6C173.89,409.6 177.02,407.48 178.33,404.23L193.45,366.4C209.58,363.57 221.87,349.46 221.87,332.54L221.87,213.6C221.87,194.64 206.44,179.2 187.47,179.2L136.53,179.2L136.53,68.27L392.53,68.27L392.53,93.87L324.53,93.87C305.57,93.87 290.13,109.3 290.13,128.26L290.13,247.2C290.13,264.13 302.43,278.24 318.55,281.07L333.68,318.9C334.98,322.14 338.11,324.27 341.6,324.27C345.1,324.27 348.23,322.14 349.52,318.9L364.44,281.6L392.53,281.6L392.53,426.67L392.53,426.67ZM438.08,238.93L416.66,238.87L416.21,238.93L365.73,238.93C347.58,238.93 332.8,223.04 332.8,203.5C332.8,191.51 338.63,180.25 347.91,173.76C352.14,160.91 364.38,152.33 377.22,153.32C385.01,142.83 396.89,136.53 409.48,136.53C430.05,136.53 447.29,153.06 450.33,174.48C461.64,179.67 469.33,191.73 469.33,205.35C469.33,223.87 455.32,238.93 438.08,238.93Z&quot;"
-        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/drawable/app_icon_v3.xml"
-            line="16"
-            column="25"/>
-    </issue>
-
-    <issue
-        id="VectorPath"
-        message="Very long vector path (950 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        errorLine1="      android:pathData=&quot;M95.61,283.22L109.78,283.22L109.78,240.69L95.61,240.69L95.61,283.22ZM102.69,311.57C104.7,311.57 106.39,310.89 107.75,309.54C109.1,308.18 109.78,306.49 109.78,304.48C109.78,302.48 109.1,300.79 107.75,299.44C106.39,298.08 104.7,297.4 102.69,297.4C100.69,297.4 99,298.08 97.65,299.44C96.29,300.79 95.61,302.48 95.61,304.48C95.61,306.49 96.29,308.18 97.65,309.54C99,310.89 100.69,311.57 102.69,311.57ZM74.34,339.93C72.33,339.93 70.65,339.25 69.29,337.88C67.93,336.53 67.25,334.84 67.25,332.84L67.25,219.43C67.25,217.42 67.93,215.73 69.29,214.37C70.65,213.02 72.33,212.34 74.34,212.34L88.52,212.34L88.52,198.16L116.87,198.16L116.87,212.34L131.05,212.34C133.05,212.34 134.74,213.02 136.1,214.37C137.45,215.73 138.14,217.42 138.14,219.43L138.14,332.84C138.14,334.84 137.45,336.53 136.1,337.88C134.74,339.25 133.05,339.93 131.05,339.93L74.34,339.93ZM81.43,325.75L123.96,325.75L123.96,226.51L81.43,226.51L81.43,325.75ZM81.43,325.75L123.96,325.75L81.43,325.75Z&quot;"
-        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/drawable-night/app_icon_v3.xml"
-            line="63"
-            column="25"/>
-    </issue>
-
-    <issue
-        id="VectorPath"
-        message="Very long vector path (950 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        errorLine1="      android:pathData=&quot;M95.61,283.22L109.78,283.22L109.78,240.69L95.61,240.69L95.61,283.22ZM102.69,311.57C104.7,311.57 106.39,310.89 107.75,309.54C109.1,308.18 109.78,306.49 109.78,304.48C109.78,302.48 109.1,300.79 107.75,299.44C106.39,298.08 104.7,297.4 102.69,297.4C100.69,297.4 99,298.08 97.65,299.44C96.29,300.79 95.61,302.48 95.61,304.48C95.61,306.49 96.29,308.18 97.65,309.54C99,310.89 100.69,311.57 102.69,311.57ZM74.34,339.93C72.33,339.93 70.65,339.25 69.29,337.88C67.93,336.53 67.25,334.84 67.25,332.84L67.25,219.43C67.25,217.42 67.93,215.73 69.29,214.37C70.65,213.02 72.33,212.34 74.34,212.34L88.52,212.34L88.52,198.16L116.87,198.16L116.87,212.34L131.05,212.34C133.05,212.34 134.74,213.02 136.1,214.37C137.45,215.73 138.14,217.42 138.14,219.43L138.14,332.84C138.14,334.84 137.45,336.53 136.1,337.88C134.74,339.25 133.05,339.93 131.05,339.93L74.34,339.93ZM81.43,325.75L123.96,325.75L123.96,226.51L81.43,226.51L81.43,325.75ZM81.43,325.75L123.96,325.75L81.43,325.75Z&quot;"
-        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/drawable/app_icon_v3.xml"
-            line="63"
-            column="25"/>
-    </issue>
-
-    <issue
-        id="VectorPath"
-        message="Very long vector path (1974 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        errorLine1="      android:pathData=&quot;M406.11,213.77C414.35,213.77 421.36,210.89 427.12,205.12C432.89,199.35 435.77,192.35 435.77,184.11C435.77,175.87 432.89,168.87 427.12,163.1C421.36,157.34 414.35,154.45 406.11,154.45C397.87,154.45 390.88,157.34 385.11,163.1C379.34,168.87 376.46,175.87 376.46,184.11C376.46,192.35 379.34,199.35 385.11,205.12C390.88,210.89 397.87,213.77 406.11,213.77ZM406.11,190.7C404.25,190.7 402.68,190.07 401.42,188.8C400.16,187.54 399.52,185.97 399.52,184.11C399.52,182.24 400.16,180.67 401.42,179.42C402.68,178.15 404.25,177.52 406.11,177.52C407.98,177.52 409.55,178.15 410.81,179.42C412.07,180.67 412.7,182.24 412.7,184.11C412.7,185.97 412.07,187.54 410.81,188.8C409.55,190.07 407.98,190.7 406.11,190.7ZM406.11,250.01C397,250.01 388.43,248.29 380.41,244.82C372.39,241.37 365.42,236.67 359.49,230.74C353.55,224.8 348.86,217.83 345.4,209.81C341.94,201.79 340.21,193.22 340.21,184.11C340.21,174.99 341.94,166.43 345.4,158.41C348.86,150.38 353.55,143.41 359.49,137.48C365.42,131.55 372.39,126.86 380.41,123.39C388.43,119.93 397,118.2 406.11,118.2C419.29,118.2 431.32,121.8 442.2,128.99C453.07,136.19 461.14,145.77 466.42,157.75L451.59,157.75C446.97,149.51 440.6,143.06 432.48,138.39C424.35,133.72 415.56,131.38 406.11,131.38C391.4,131.38 378.93,136.49 368.71,146.71C358.5,156.92 353.39,169.39 353.39,184.11C353.39,198.82 358.5,211.29 368.71,221.51C378.93,231.72 391.4,236.83 406.11,236.83C413.69,236.83 420.94,235.27 427.86,232.14C434.78,229.01 440.71,224.53 445.66,218.71L445.66,236.83C439.84,241 433.58,244.25 426.87,246.55C420.17,248.86 413.25,250.01 406.11,250.01ZM458.84,223.65L458.84,170.93L472.02,170.93L472.02,223.65L458.84,223.65ZM465.43,250.01C463.56,250.01 461.99,249.38 460.74,248.11C459.47,246.86 458.84,245.29 458.84,243.42C458.84,241.56 459.47,239.99 460.74,238.73C461.99,237.46 463.56,236.83 465.43,236.83C467.29,236.83 468.86,237.46 470.13,238.73C471.39,239.99 472.02,241.56 472.02,243.42C472.02,245.29 471.39,246.86 470.13,248.11C468.86,249.38 467.29,250.01 465.43,250.01Z&quot;"
-        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/drawable-night/app_icon_v3.xml"
-            line="67"
-            column="25"/>
-    </issue>
-
-    <issue
-        id="VectorPath"
-        message="Very long vector path (1974 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        errorLine1="      android:pathData=&quot;M406.11,213.77C414.35,213.77 421.36,210.89 427.12,205.12C432.89,199.35 435.77,192.35 435.77,184.11C435.77,175.87 432.89,168.87 427.12,163.1C421.36,157.34 414.35,154.45 406.11,154.45C397.87,154.45 390.88,157.34 385.11,163.1C379.34,168.87 376.46,175.87 376.46,184.11C376.46,192.35 379.34,199.35 385.11,205.12C390.88,210.89 397.87,213.77 406.11,213.77ZM406.11,190.7C404.25,190.7 402.68,190.07 401.42,188.8C400.16,187.54 399.52,185.97 399.52,184.11C399.52,182.24 400.16,180.67 401.42,179.42C402.68,178.15 404.25,177.52 406.11,177.52C407.98,177.52 409.55,178.15 410.81,179.42C412.07,180.67 412.7,182.24 412.7,184.11C412.7,185.97 412.07,187.54 410.81,188.8C409.55,190.07 407.98,190.7 406.11,190.7ZM406.11,250.01C397,250.01 388.43,248.29 380.41,244.82C372.39,241.37 365.42,236.67 359.49,230.74C353.55,224.8 348.86,217.83 345.4,209.81C341.94,201.79 340.21,193.22 340.21,184.11C340.21,174.99 341.94,166.43 345.4,158.41C348.86,150.38 353.55,143.41 359.49,137.48C365.42,131.55 372.39,126.86 380.41,123.39C388.43,119.93 397,118.2 406.11,118.2C419.29,118.2 431.32,121.8 442.2,128.99C453.07,136.19 461.14,145.77 466.42,157.75L451.59,157.75C446.97,149.51 440.6,143.06 432.48,138.39C424.35,133.72 415.56,131.38 406.11,131.38C391.4,131.38 378.93,136.49 368.71,146.71C358.5,156.92 353.39,169.39 353.39,184.11C353.39,198.82 358.5,211.29 368.71,221.51C378.93,231.72 391.4,236.83 406.11,236.83C413.69,236.83 420.94,235.27 427.86,232.14C434.78,229.01 440.71,224.53 445.66,218.71L445.66,236.83C439.84,241 433.58,244.25 426.87,246.55C420.17,248.86 413.25,250.01 406.11,250.01ZM458.84,223.65L458.84,170.93L472.02,170.93L472.02,223.65L458.84,223.65ZM465.43,250.01C463.56,250.01 461.99,249.38 460.74,248.11C459.47,246.86 458.84,245.29 458.84,243.42C458.84,241.56 459.47,239.99 460.74,238.73C461.99,237.46 463.56,236.83 465.43,236.83C467.29,236.83 468.86,237.46 470.13,238.73C471.39,239.99 472.02,241.56 472.02,243.42C472.02,245.29 471.39,246.86 470.13,248.11C468.86,249.38 467.29,250.01 465.43,250.01Z&quot;"
-        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/drawable/app_icon_v3.xml"
-            line="67"
-            column="25"/>
-    </issue>
-
-    <issue
-        id="VectorPath"
-        message="Very long vector path (2585 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        errorLine1="        android:pathData=&quot;M477.6,93.87L409.6,93.87L409.6,33.81C409.6,15.16 394.44,0 375.79,0L153.28,0C134.63,0 119.47,15.16 119.47,33.81L119.47,76.8C114.75,76.8 110.93,80.61 110.93,85.33L110.93,93.87C110.93,98.58 114.75,102.4 119.47,102.4L119.47,110.93C114.75,110.93 110.93,114.75 110.93,119.46L110.93,128C110.93,132.72 114.75,136.53 119.47,136.53L119.47,179.2L34.4,179.2C15.44,179.2 0,194.64 0,213.6L0,332.54C0,351.5 15.44,366.93 34.4,366.93L119.47,366.93L119.47,478.19C119.47,496.84 134.63,512 153.28,512L375.79,512C394.44,512 409.6,496.84 409.6,478.19L409.6,281.6L477.6,281.6C496.57,281.6 512,266.16 512,247.2L512,128.26C512,109.3 496.57,93.87 477.6,93.87ZM136.53,33.81C136.53,24.58 144.04,17.07 153.27,17.07L375.79,17.07C385.02,17.07 392.53,24.58 392.53,33.81L392.53,51.2L136.53,51.2L136.53,33.81L136.53,33.81ZM68.27,332.8C63.55,332.8 59.73,328.99 59.73,324.27L59.73,264.53C59.73,259.82 63.55,256 68.27,256L76.8,256L76.8,247.47C76.8,228.64 92.11,213.34 110.93,213.34C129.76,213.34 145.07,228.64 145.07,247.47L145.07,256L153.6,256C158.32,256 162.13,259.81 162.13,264.53L162.13,324.27C162.13,328.98 158.32,332.8 153.6,332.8L68.27,332.8L68.27,332.8ZM242.19,494.93L153.28,494.93C144.04,494.93 136.53,487.42 136.53,478.19L136.53,443.73L242.19,443.73C235.03,450 230.4,459.09 230.4,469.33C230.4,479.57 235.02,488.67 242.19,494.93ZM264.53,486.4C255.13,486.4 247.47,478.75 247.47,469.33C247.47,459.92 255.13,452.27 264.53,452.27C273.95,452.27 281.6,459.92 281.6,469.33C281.6,478.75 273.95,486.4 264.53,486.4ZM392.53,478.19C392.53,487.42 385.02,494.93 375.79,494.93L286.87,494.93C294.04,488.67 298.67,479.57 298.67,469.33C298.67,459.09 294.04,450 286.87,443.73L392.53,443.73L392.53,478.19L392.53,478.19ZM392.53,426.67L136.53,426.67L136.53,366.93L147.56,366.93L162.47,404.23C163.77,407.48 166.91,409.6 170.4,409.6C173.89,409.6 177.02,407.48 178.33,404.23L193.45,366.4C209.58,363.57 221.87,349.46 221.87,332.54L221.87,213.6C221.87,194.64 206.44,179.2 187.47,179.2L136.53,179.2L136.53,68.27L392.53,68.27L392.53,93.87L324.53,93.87C305.57,93.87 290.13,109.3 290.13,128.26L290.13,247.2C290.13,264.13 302.43,278.24 318.55,281.07L333.68,318.9C334.98,322.14 338.11,324.27 341.6,324.27C345.1,324.27 348.23,322.14 349.52,318.9L364.44,281.6L392.53,281.6L392.53,426.67L392.53,426.67ZM438.08,238.93L416.66,238.87L416.21,238.93L365.73,238.93C347.58,238.93 332.8,223.04 332.8,203.5C332.8,191.51 338.63,180.25 347.91,173.76C352.14,160.91 364.38,152.33 377.22,153.32C385.01,142.83 396.89,136.53 409.48,136.53C430.05,136.53 447.29,153.06 450.33,174.48C461.64,179.67 469.33,191.73 469.33,205.35C469.33,223.87 455.32,238.93 438.08,238.93Z&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/drawable/ic_launcher_foreground.xml"
-            line="20"
-            column="27"/>
-    </issue>
-
-    <issue
-        id="VectorPath"
-        message="Very long vector path (950 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        errorLine1="        android:pathData=&quot;M95.61,283.22L109.78,283.22L109.78,240.69L95.61,240.69L95.61,283.22ZM102.69,311.57C104.7,311.57 106.39,310.89 107.75,309.54C109.1,308.18 109.78,306.49 109.78,304.48C109.78,302.48 109.1,300.79 107.75,299.44C106.39,298.08 104.7,297.4 102.69,297.4C100.69,297.4 99,298.08 97.65,299.44C96.29,300.79 95.61,302.48 95.61,304.48C95.61,306.49 96.29,308.18 97.65,309.54C99,310.89 100.69,311.57 102.69,311.57ZM74.34,339.93C72.33,339.93 70.65,339.25 69.29,337.88C67.93,336.53 67.25,334.84 67.25,332.84L67.25,219.43C67.25,217.42 67.93,215.73 69.29,214.37C70.65,213.02 72.33,212.34 74.34,212.34L88.52,212.34L88.52,198.16L116.87,198.16L116.87,212.34L131.05,212.34C133.05,212.34 134.74,213.02 136.1,214.37C137.45,215.73 138.14,217.42 138.14,219.43L138.14,332.84C138.14,334.84 137.45,336.53 136.1,337.88C134.74,339.25 133.05,339.93 131.05,339.93L74.34,339.93ZM81.43,325.75L123.96,325.75L123.96,226.51L81.43,226.51L81.43,325.75ZM81.43,325.75L123.96,325.75L81.43,325.75Z&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/drawable/ic_launcher_foreground.xml"
-            line="67"
-            column="27"/>
-    </issue>
-
-    <issue
-        id="VectorPath"
-        message="Very long vector path (1974 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        errorLine1="        android:pathData=&quot;M406.11,213.77C414.35,213.77 421.36,210.89 427.12,205.12C432.89,199.35 435.77,192.35 435.77,184.11C435.77,175.87 432.89,168.87 427.12,163.1C421.36,157.34 414.35,154.45 406.11,154.45C397.87,154.45 390.88,157.34 385.11,163.1C379.34,168.87 376.46,175.87 376.46,184.11C376.46,192.35 379.34,199.35 385.11,205.12C390.88,210.89 397.87,213.77 406.11,213.77ZM406.11,190.7C404.25,190.7 402.68,190.07 401.42,188.8C400.16,187.54 399.52,185.97 399.52,184.11C399.52,182.24 400.16,180.67 401.42,179.42C402.68,178.15 404.25,177.52 406.11,177.52C407.98,177.52 409.55,178.15 410.81,179.42C412.07,180.67 412.7,182.24 412.7,184.11C412.7,185.97 412.07,187.54 410.81,188.8C409.55,190.07 407.98,190.7 406.11,190.7ZM406.11,250.01C397,250.01 388.43,248.29 380.41,244.82C372.39,241.37 365.42,236.67 359.49,230.74C353.55,224.8 348.86,217.83 345.4,209.81C341.94,201.79 340.21,193.22 340.21,184.11C340.21,174.99 341.94,166.43 345.4,158.41C348.86,150.38 353.55,143.41 359.49,137.48C365.42,131.55 372.39,126.86 380.41,123.39C388.43,119.93 397,118.2 406.11,118.2C419.29,118.2 431.32,121.8 442.2,128.99C453.07,136.19 461.14,145.77 466.42,157.75L451.59,157.75C446.97,149.51 440.6,143.06 432.48,138.39C424.35,133.72 415.56,131.38 406.11,131.38C391.4,131.38 378.93,136.49 368.71,146.71C358.5,156.92 353.39,169.39 353.39,184.11C353.39,198.82 358.5,211.29 368.71,221.51C378.93,231.72 391.4,236.83 406.11,236.83C413.69,236.83 420.94,235.27 427.86,232.14C434.78,229.01 440.71,224.53 445.66,218.71L445.66,236.83C439.84,241 433.58,244.25 426.87,246.55C420.17,248.86 413.25,250.01 406.11,250.01ZM458.84,223.65L458.84,170.93L472.02,170.93L472.02,223.65L458.84,223.65ZM465.43,250.01C463.56,250.01 461.99,249.38 460.74,248.11C459.47,246.86 458.84,245.29 458.84,243.42C458.84,241.56 459.47,239.99 460.74,238.73C461.99,237.46 463.56,236.83 465.43,236.83C467.29,236.83 468.86,237.46 470.13,238.73C471.39,239.99 472.02,241.56 472.02,243.42C472.02,245.29 471.39,246.86 470.13,248.11C468.86,249.38 467.29,250.01 465.43,250.01Z&quot;"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/drawable/ic_launcher_foreground.xml"
-            line="71"
-            column="27"/>
-    </issue>
-
-    <issue
-        id="VectorPath"
-        message="Very long vector path (1245 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        errorLine1="        android:pathData=&quot;M21.949,12C22.598,11.365 23,10.479 23,9.5C23,7.567 21.433,6 19.5,6C18.963,6 18.455,6.121 18,6.337V4.5C18,2.567 16.433,1 14.5,1C13.521,1 12.635,1.402 12,2.051C11.365,1.402 10.479,1 9.5,1C7.567,1 6,2.567 6,4.5C6,5.037 6.121,5.545 6.337,6H4.5C2.567,6 1,7.567 1,9.5C1,10.479 1.402,11.365 2.051,12C1.402,12.635 1,13.521 1,14.5C1,16.433 2.567,18 4.5,18C5.037,18 5.545,17.879 6,17.663V19.5C6,21.433 7.567,23 9.5,23C10.479,23 11.365,22.598 12,21.949C12.635,22.598 13.521,23 14.5,23C16.433,23 18,21.433 18,19.5C18,18.963 17.879,18.455 17.663,18H19.5C21.433,18 23,16.433 23,14.5C23,13.521 22.598,12.635 21.949,12ZM9.5,3C10.328,3 11,3.672 11,4.5V6H9.5C8.672,6 8,5.328 8,4.5C8,3.672 8.672,3 9.5,3ZM13,4.5C13,3.672 13.672,3 14.5,3C15.328,3 16,3.672 16,4.5V11H13V4.5ZM11,11V8H4.5C3.672,8 3,8.672 3,9.5C3,10.328 3.672,11 4.5,11H11ZM18,11H19.5C20.328,11 21,10.328 21,9.5C21,8.672 20.328,8 19.5,8C18.672,8 18,8.672 18,9.5V11ZM19.5,13H13V16H19.5C20.328,16 21,15.328 21,14.5C21,13.672 20.328,13 19.5,13ZM14.5,18H13V19.5C13,20.328 13.672,21 14.5,21C15.328,21 16,20.328 16,19.5C16,18.672 15.328,18 14.5,18ZM11,13H8V19.5C8,20.328 8.672,21 9.5,21C10.328,21 11,20.328 11,19.5V13ZM4.5,13H6V14.5C6,15.328 5.328,16 4.5,16C3.672,16 3,15.328 3,14.5C3,13.672 3.672,13 4.5,13Z&quot; />"
-        errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/drawable/slack_logo_outline.xml"
-            line="18"
-            column="27"/>
-    </issue>
-
-    <issue
-        id="VectorPath"
-        message="Very long vector path (811 characters), which is bad for performance. Considering reducing precision, removing minor details or rasterizing vector."
-        errorLine1="      android:pathData=&quot;M280,840q-83,0 -141.5,-58.5T80,640q0,-73 45.5,-127.5T240,444v83q-35,12 -57.5,43T160,640q0,50 35,85t85,35q50,0 85,-35t35,-85v-40h235q8,-9 19.5,-14.5T680,580q25,0 42.5,17.5T740,640q0,25 -17.5,42.5T680,700q-14,0 -25.5,-5.5T635,680L476,680q-14,69 -68.5,114.5T280,840ZM680,840q-56,0 -101.5,-27.5T507,740h107q14,10 31,15t35,5q50,0 85,-35t35,-85q0,-50 -35,-85t-85,-35q-20,0 -37,5.5T611,542L489,339q-21,-4 -35,-20t-14,-39q0,-25 17.5,-42.5T500,220q25,0 42.5,17.5T560,280v8.5q0,3.5 -2,8.5l87,146q8,-2 17,-2.5t18,-0.5q83,0 141.5,58.5T880,640q0,83 -58.5,141.5T680,840ZM280,700q-25,0 -42.5,-17.5T220,640q0,-22 14,-38t34,-21l94,-156q-29,-27 -45.5,-64.5T300,280q0,-83 58.5,-141.5T500,80q83,0 141.5,58.5T700,280h-80q0,-50 -35,-85t-85,-35q-50,0 -85,35t-35,85q0,43 26,75.5t66,41.5L337,622q2,5 2.5,9t0.5,9q0,25 -17.5,42.5T280,700Z&quot;"
-        errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/drawable/webhook_24dp.xml"
-            line="7"
-            column="25"/>
     </issue>
 
     <issue

--- a/app/schemas/dev.hossain.remotenotify.db.AppDatabase/3.json
+++ b/app/schemas/dev.hossain.remotenotify.db.AppDatabase/3.json
@@ -1,0 +1,141 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "593d557d9f4ab346d28695cb37725e0b",
+    "entities": [
+      {
+        "tableName": "alert_config",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `battery_percentage` INTEGER NOT NULL DEFAULT -1, `storage_min_space_gb` INTEGER NOT NULL DEFAULT -1, `alert_mode` TEXT NOT NULL DEFAULT 'THRESHOLD', `created_on` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "batteryPercentage",
+            "columnName": "battery_percentage",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "storageMinSpaceGb",
+            "columnName": "storage_min_space_gb",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "alertMode",
+            "columnName": "alert_mode",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'THRESHOLD'"
+          },
+          {
+            "fieldPath": "createdOn",
+            "columnName": "created_on",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "alert_check_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `alert_config_id` INTEGER NOT NULL, `checked_at` INTEGER NOT NULL, `alert_state_value` INTEGER NOT NULL, `is_alert_triggered` INTEGER NOT NULL, `alert_type` TEXT NOT NULL, `notifier_type` TEXT, FOREIGN KEY(`alert_config_id`) REFERENCES `alert_config`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertConfigId",
+            "columnName": "alert_config_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checkedAt",
+            "columnName": "checked_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertStateValue",
+            "columnName": "alert_state_value",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertTriggered",
+            "columnName": "is_alert_triggered",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertType",
+            "columnName": "alert_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notifierType",
+            "columnName": "notifier_type",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_alert_check_log_alert_config_id",
+            "unique": false,
+            "columnNames": [
+              "alert_config_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_alert_check_log_alert_config_id` ON `${TABLE_NAME}` (`alert_config_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "alert_config",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "alert_config_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '593d557d9f4ab346d28695cb37725e0b')"
+    ]
+  }
+}

--- a/app/src/main/java/dev/hossain/remotenotify/data/AlertFormatter.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/AlertFormatter.kt
@@ -1,5 +1,6 @@
 package dev.hossain.remotenotify.data
 
+import dev.hossain.remotenotify.model.AlertMode
 import dev.hossain.remotenotify.model.AlertType
 import dev.hossain.remotenotify.model.DeviceAlert
 import dev.hossain.remotenotify.model.DeviceAlert.FormatType
@@ -39,11 +40,14 @@ class AlertFormatter
                             batteryLevel = remoteAlert.currentBatteryLevel ?: remoteAlert.batteryPercentage,
                             // Only show threshold label when current value is present
                             batteryThresholdPercent =
-                                if (remoteAlert.currentBatteryLevel != null) {
+                                if (remoteAlert.alertMode == AlertMode.THRESHOLD &&
+                                    remoteAlert.currentBatteryLevel != null
+                                ) {
                                     remoteAlert.batteryPercentage
                                 } else {
                                     null
                                 },
+                            isStatusReport = remoteAlert.alertMode == AlertMode.PERIODIC,
                         )
                     }
 
@@ -54,13 +58,14 @@ class AlertFormatter
                             availableStorageGb = remoteAlert.currentStorageGb ?: remoteAlert.storageMinSpaceGb.toDouble(),
                             // Only show threshold label when current value is present
                             storageThresholdGb =
-                                if (remoteAlert.currentStorageGb !=
-                                    null
+                                if (remoteAlert.alertMode == AlertMode.THRESHOLD &&
+                                    remoteAlert.currentStorageGb != null
                                 ) {
                                     remoteAlert.storageMinSpaceGb.toDouble()
                                 } else {
                                     null
                                 },
+                            isStatusReport = remoteAlert.alertMode == AlertMode.PERIODIC,
                         )
                     }
                 }

--- a/app/src/main/java/dev/hossain/remotenotify/data/export/AppConfiguration.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/export/AppConfiguration.kt
@@ -1,6 +1,7 @@
 package dev.hossain.remotenotify.data.export
 
 import com.squareup.moshi.JsonClass
+import dev.hossain.remotenotify.model.AlertMode
 import dev.hossain.remotenotify.model.AlertType
 import dev.hossain.remotenotify.notifier.NotifierType
 
@@ -25,7 +26,7 @@ data class AppConfiguration(
     val preferences: AppPreferences = AppPreferences(),
 ) {
     companion object {
-        const val CURRENT_VERSION = 1
+        const val CURRENT_VERSION = 2
     }
 }
 
@@ -37,6 +38,7 @@ data class AlertConfig(
     val type: AlertType,
     val batteryPercentage: Int? = null,
     val storageMinSpaceGb: Int? = null,
+    val alertMode: AlertMode = AlertMode.THRESHOLD,
 )
 
 /**

--- a/app/src/main/java/dev/hossain/remotenotify/data/export/ConfigurationExporter.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/export/ConfigurationExporter.kt
@@ -77,6 +77,7 @@ class ConfigurationExporter
                         AlertConfig(
                             type = AlertType.BATTERY,
                             batteryPercentage = alert.batteryPercentage,
+                            alertMode = alert.alertMode,
                         )
                     }
 
@@ -84,6 +85,7 @@ class ConfigurationExporter
                         AlertConfig(
                             type = AlertType.STORAGE,
                             storageMinSpaceGb = alert.storageMinSpaceGb,
+                            alertMode = alert.alertMode,
                         )
                     }
                 }

--- a/app/src/main/java/dev/hossain/remotenotify/data/export/ConfigurationImporter.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/export/ConfigurationImporter.kt
@@ -10,6 +10,7 @@ import dev.hossain.remotenotify.data.TelegramConfigDataStore
 import dev.hossain.remotenotify.data.TwilioConfigDataStore
 import dev.hossain.remotenotify.data.WebhookConfigDataStore
 import dev.hossain.remotenotify.model.AlertMediumConfig
+import dev.hossain.remotenotify.model.AlertMode
 import dev.hossain.remotenotify.model.AlertType
 import dev.hossain.remotenotify.model.RemoteAlert
 import dev.zacsweers.metro.AppScope
@@ -145,18 +146,24 @@ class ConfigurationImporter
             configuration.alerts.forEach { alert ->
                 when (alert.type) {
                     AlertType.BATTERY -> {
-                        if (alert.batteryPercentage == null) {
+                        if (alert.alertMode == AlertMode.THRESHOLD && alert.batteryPercentage == null) {
                             errors.add("Battery alert missing batteryPercentage")
-                        } else if (alert.batteryPercentage < 0 || alert.batteryPercentage > 100) {
-                            errors.add("Invalid battery percentage: ${alert.batteryPercentage}")
+                        }
+                        alert.batteryPercentage?.let { batteryPercentage ->
+                            if (batteryPercentage < 0 || batteryPercentage > 100) {
+                                errors.add("Invalid battery percentage: $batteryPercentage")
+                            }
                         }
                     }
 
                     AlertType.STORAGE -> {
-                        if (alert.storageMinSpaceGb == null) {
+                        if (alert.alertMode == AlertMode.THRESHOLD && alert.storageMinSpaceGb == null) {
                             errors.add("Storage alert missing storageMinSpaceGb")
-                        } else if (alert.storageMinSpaceGb < 0) {
-                            errors.add("Invalid storage space: ${alert.storageMinSpaceGb}")
+                        }
+                        alert.storageMinSpaceGb?.let { storageMinSpaceGb ->
+                            if (storageMinSpaceGb < 0) {
+                                errors.add("Invalid storage space: $storageMinSpaceGb")
+                            }
                         }
                     }
                 }
@@ -188,12 +195,14 @@ class ConfigurationImporter
                         AlertType.BATTERY -> {
                             RemoteAlert.BatteryAlert(
                                 batteryPercentage = alertConfig.batteryPercentage ?: 20,
+                                alertMode = alertConfig.alertMode,
                             )
                         }
 
                         AlertType.STORAGE -> {
                             RemoteAlert.StorageAlert(
                                 storageMinSpaceGb = alertConfig.storageMinSpaceGb ?: 1,
+                                alertMode = alertConfig.alertMode,
                             )
                         }
                     }

--- a/app/src/main/java/dev/hossain/remotenotify/db/AlertConfigEntity.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/db/AlertConfigEntity.kt
@@ -3,6 +3,7 @@ package dev.hossain.remotenotify.db
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import dev.hossain.remotenotify.model.AlertMode
 import dev.hossain.remotenotify.model.AlertType
 import dev.hossain.remotenotify.model.BATTERY_PERCENTAGE_NONE
 import dev.hossain.remotenotify.model.STORAGE_MIN_SPACE_GB_NONE
@@ -15,6 +16,8 @@ data class AlertConfigEntity(
     val batteryPercentage: Int,
     @ColumnInfo(name = "storage_min_space_gb", defaultValue = STORAGE_MIN_SPACE_GB_NONE.toString())
     val storageMinSpaceGb: Int,
+    @ColumnInfo(name = "alert_mode", defaultValue = "'THRESHOLD'")
+    val alertMode: AlertMode = AlertMode.THRESHOLD,
     @ColumnInfo(name = "created_on")
     val createdOn: Long = System.currentTimeMillis(),
 )

--- a/app/src/main/java/dev/hossain/remotenotify/db/AppDatabase.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/db/AppDatabase.kt
@@ -12,12 +12,15 @@ import androidx.room.RoomDatabase
  */
 @Database(
     entities = [AlertConfigEntity::class, AlertCheckLogEntity::class],
-    version = 2,
+    version = 3,
     exportSchema = true,
     // https://developer.android.com/training/data-storage/room/migrating-db-versions
     // https://github.com/hossain-khan/android-weather-alert/issues/272#issuecomment-2629512823
     // https://medium.com/androiddevelopers/room-auto-migrations-d5370b0ca6eb
-    autoMigrations = [AutoMigration(from = 1, to = 2)],
+    autoMigrations = [
+        AutoMigration(from = 1, to = 2),
+        AutoMigration(from = 2, to = 3),
+    ],
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun notificationDao(): AlertConfigDao

--- a/app/src/main/java/dev/hossain/remotenotify/model/AlertMode.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/model/AlertMode.kt
@@ -1,0 +1,19 @@
+package dev.hossain.remotenotify.model
+
+import androidx.annotation.Keep
+
+/**
+ * Defines when a configured alert sends a remote notification.
+ */
+@Keep
+enum class AlertMode {
+    /**
+     * Send only when the configured threshold condition is met.
+     */
+    THRESHOLD,
+
+    /**
+     * Send the current metric every time the periodic worker runs.
+     */
+    PERIODIC,
+}

--- a/app/src/main/java/dev/hossain/remotenotify/model/DeviceAlert.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/model/DeviceAlert.kt
@@ -118,7 +118,11 @@ data class DeviceAlert(
             }
 
         return buildString {
-            append("⚠️ ${alertType.name.toTitleCase()} Alert")
+            if (isStatusReport) {
+                append("ℹ️ ${alertType.name.toTitleCase()} Status Report")
+            } else {
+                append("⚠️ ${alertType.name.toTitleCase()} Alert")
+            }
             append("\n📱 ${deviceName()}")
             append("\n📍 Android $androidVersion")
             append("\n${getAlertEmoji()} $alertMessage")
@@ -190,11 +194,16 @@ data class DeviceAlert(
             }
 
         return buildString {
-            append("${getAlertEmoji()} Alert: ${alertType.name.toTitleCase()} Low\n\n")
+            if (isStatusReport) {
+                append("ℹ️ Status Report: ${alertType.name.toTitleCase()}\n\n")
+            } else {
+                append("${getAlertEmoji()} Alert: ${alertType.name.toTitleCase()} Low\n\n")
+            }
             append("📱 Device: ${deviceName()}\n")
             append("📍 System: Android $androidVersion\n")
             append("ℹ️ Status: $message\n")
-            append("⚡ Action: $action\n\n")
+            val actionPrefix = if (isStatusReport) "ℹ️ Action: " else "⚡ Action: "
+            append("$actionPrefix$action\n\n")
             append("🕒 Reported on: $formattedTimestamp")
         }
     }
@@ -262,14 +271,23 @@ data class DeviceAlert(
                 }
             }
 
+        val headerColor = if (isStatusReport) "#1976d2" else "#d32f2f"
+        val headerTitle =
+            if (isStatusReport) {
+                "ℹ️ ${alertType.name.toTitleCase()} Status Report"
+            } else {
+                "${getAlertEmoji()} ${alertType.name.toTitleCase()} Alert"
+            }
+        val actionLabel = if (isStatusReport) "ℹ️ Action:" else "⚡ Action Required:"
+
         return """
             <div style="font-family: sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
-                <h2 style="color: #d32f2f;">${getAlertEmoji()} ${alertType.name.toTitleCase()} Alert</h2>
+                <h2 style="color: $headerColor;">$headerTitle</h2>
                 <div style="background: #f5f5f5; padding: 15px; border-radius: 8px; margin: 15px 0;">
                     <p style="margin: 5px 0;"><strong>📱 Device:</strong> ${deviceName()}</p>
                     <p style="margin: 5px 0;"><strong>📍 System:</strong> Android $androidVersion</p>
                     <p style="margin: 5px 0;"><strong>ℹ️ Status:</strong> $message</p>
-                    <p style="margin: 5px 0;"><strong>⚡ Action Required:</strong> $action</p>
+                    <p style="margin: 5px 0;"><strong>$actionLabel</strong> $action</p>
                     <p style="margin: 5px 0; color: #666;"><strong>🕒 Reported on:</strong> $formattedTimestamp</p>
                 </div>
                 <p style="font-size: 12px; color: #666;">

--- a/app/src/main/java/dev/hossain/remotenotify/model/DeviceAlert.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/model/DeviceAlert.kt
@@ -28,6 +28,8 @@ data class DeviceAlert(
     val availableStorageGb: Double? = null,
     /** The storage threshold in Gigabytes (GB) that triggered this alert. Null if not applicable to storage alerts. */
     val storageThresholdGb: Double? = null,
+    /** Whether this is a scheduled status report rather than a threshold-triggered alert. */
+    val isStatusReport: Boolean = false,
     /** The timestamp when the alert was generated. Defaults to the current time. */
     val timestamp: LocalDateTime = LocalDateTime.now(),
 ) {
@@ -89,7 +91,7 @@ data class DeviceAlert(
                         }
 
                         batteryLevel != null -> {
-                            "Battery Level is at $batteryLevel%"
+                            "Battery Level: $batteryLevel%"
                         }
 
                         else -> {
@@ -137,14 +139,22 @@ data class DeviceAlert(
                             }
 
                             batteryLevel != null -> {
-                                "Device battery is critically low at $batteryLevel%"
+                                if (isStatusReport) {
+                                    "Device battery level is $batteryLevel%"
+                                } else {
+                                    "Device battery is critically low at $batteryLevel%"
+                                }
                             }
 
                             else -> {
                                 "Device battery is critically low"
                             }
                         },
-                        "Please connect your device to a charger to prevent shutdown.",
+                        if (batteryThresholdPercent != null || !isStatusReport) {
+                            "Please connect your device to a charger to prevent shutdown."
+                        } else {
+                            "No action required."
+                        },
                     )
                 }
 
@@ -152,18 +162,29 @@ data class DeviceAlert(
                     Pair(
                         when {
                             storageThresholdGb != null && availableStorageGb != null -> {
-                                "Available storage space is critically low (Current: $availableStorageGb GB, Threshold: $storageThresholdGb GB)"
+                                buildString {
+                                    append("Available storage space is critically low ")
+                                    append("(Current: $availableStorageGb GB, Threshold: $storageThresholdGb GB)")
+                                }
                             }
 
                             availableStorageGb != null -> {
-                                "Available storage space is low ($availableStorageGb GB)"
+                                if (isStatusReport) {
+                                    "Available storage space is $availableStorageGb GB"
+                                } else {
+                                    "Available storage space is low ($availableStorageGb GB)"
+                                }
                             }
 
                             else -> {
                                 "Available storage space is low"
                             }
                         },
-                        "Consider removing unused apps or media files to free up space.",
+                        if (storageThresholdGb != null || !isStatusReport) {
+                            "Consider removing unused apps or media files to free up space."
+                        } else {
+                            "No action required."
+                        },
                     )
                 }
             }
@@ -191,14 +212,22 @@ data class DeviceAlert(
                             }
 
                             batteryLevel != null -> {
-                                "Device battery is critically low at $batteryLevel%"
+                                if (isStatusReport) {
+                                    "Device battery level is $batteryLevel%"
+                                } else {
+                                    "Device battery is critically low at $batteryLevel%"
+                                }
                             }
 
                             else -> {
                                 "Device battery is critically low"
                             }
                         },
-                        "Please connect your device to a charger to prevent shutdown.",
+                        if (batteryThresholdPercent != null || !isStatusReport) {
+                            "Please connect your device to a charger to prevent shutdown."
+                        } else {
+                            "No action required."
+                        },
                     )
                 }
 
@@ -206,18 +235,29 @@ data class DeviceAlert(
                     Pair(
                         when {
                             storageThresholdGb != null && availableStorageGb != null -> {
-                                "Available storage space is critically low (Current: $availableStorageGb GB, Threshold: $storageThresholdGb GB)"
+                                buildString {
+                                    append("Available storage space is critically low ")
+                                    append("(Current: $availableStorageGb GB, Threshold: $storageThresholdGb GB)")
+                                }
                             }
 
                             availableStorageGb != null -> {
-                                "Available storage space is low ($availableStorageGb GB)"
+                                if (isStatusReport) {
+                                    "Available storage space is $availableStorageGb GB"
+                                } else {
+                                    "Available storage space is low ($availableStorageGb GB)"
+                                }
                             }
 
                             else -> {
                                 "Available storage space is low"
                             }
                         },
-                        "Consider removing unused apps or media files to free up space.",
+                        if (storageThresholdGb != null || !isStatusReport) {
+                            "Consider removing unused apps or media files to free up space."
+                        } else {
+                            "No action required."
+                        },
                     )
                 }
             }

--- a/app/src/main/java/dev/hossain/remotenotify/model/RemoteAlert.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/model/RemoteAlert.kt
@@ -18,6 +18,11 @@ sealed interface RemoteAlert {
     val alertId: Long
 
     /**
+     * Defines whether this alert sends only when the threshold is met or every periodic worker run.
+     */
+    val alertMode: AlertMode
+
+    /**
      * Represents an alert condition based on battery percentage.
      * The alert is typically triggered when the battery level drops to or below the specified [batteryPercentage].
      *
@@ -29,6 +34,7 @@ sealed interface RemoteAlert {
         override val alertId: Long = 0,
         val batteryPercentage: Int,
         val currentBatteryLevel: Int? = null,
+        override val alertMode: AlertMode = AlertMode.THRESHOLD,
     ) : RemoteAlert
 
     /**
@@ -43,6 +49,7 @@ sealed interface RemoteAlert {
         override val alertId: Long = 0,
         val storageMinSpaceGb: Int,
         val currentStorageGb: Double? = null,
+        override val alertMode: AlertMode = AlertMode.THRESHOLD,
     ) : RemoteAlert
 }
 
@@ -58,6 +65,7 @@ internal fun RemoteAlert.toAlertConfigEntity(): AlertConfigEntity =
                 batteryPercentage = batteryPercentage,
                 type = AlertType.BATTERY,
                 storageMinSpaceGb = 0,
+                alertMode = alertMode,
             )
         }
 
@@ -67,6 +75,7 @@ internal fun RemoteAlert.toAlertConfigEntity(): AlertConfigEntity =
                 storageMinSpaceGb = storageMinSpaceGb,
                 type = AlertType.STORAGE,
                 batteryPercentage = 0,
+                alertMode = alertMode,
             )
         }
     }
@@ -87,8 +96,8 @@ internal fun RemoteAlert.toAlertType(): AlertType =
  */
 internal fun AlertConfigEntity.toRemoteAlert(): RemoteAlert =
     when (type) {
-        AlertType.BATTERY -> RemoteAlert.BatteryAlert(id, batteryPercentage)
-        AlertType.STORAGE -> RemoteAlert.StorageAlert(id, storageMinSpaceGb)
+        AlertType.BATTERY -> RemoteAlert.BatteryAlert(id, batteryPercentage, alertMode = alertMode)
+        AlertType.STORAGE -> RemoteAlert.StorageAlert(id, storageMinSpaceGb, alertMode = alertMode)
     }
 
 /**

--- a/app/src/main/java/dev/hossain/remotenotify/notifier/DiscordWebhookNotificationSender.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/notifier/DiscordWebhookNotificationSender.kt
@@ -3,6 +3,7 @@ package dev.hossain.remotenotify.notifier
 import dev.hossain.remotenotify.data.ConfigValidationResult
 import dev.hossain.remotenotify.data.DiscordWebhookConfigDataStore
 import dev.hossain.remotenotify.model.AlertMediumConfig
+import dev.hossain.remotenotify.model.AlertMode
 import dev.hossain.remotenotify.model.RemoteAlert
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoSet
@@ -31,6 +32,7 @@ class DiscordWebhookNotificationSender
             // Discord embed color codes (decimal)
             private const val COLOR_BATTERY_CRITICAL = 16711680 // #FF0000 (red)
             private const val COLOR_STORAGE_CRITICAL = 16753920 // #FFA500 (orange)
+            private const val COLOR_STATUS_REPORT = 3447003 // #3498DB (blue)
         }
 
         override suspend fun sendNotification(remoteAlert: RemoteAlert): Boolean {
@@ -63,20 +65,29 @@ class DiscordWebhookNotificationSender
             val deviceName = "${android.os.Build.BRAND.replaceFirstChar {
                 if (it.isLowerCase()) it.titlecase(Locale.US) else it.toString()
             }} ${android.os.Build.MODEL}"
+            val isPeriodic = remoteAlert.alertMode == AlertMode.PERIODIC
 
             return when (remoteAlert) {
                 is RemoteAlert.BatteryAlert -> {
                     val currentLevel = remoteAlert.currentBatteryLevel ?: remoteAlert.batteryPercentage
                     val threshold = remoteAlert.batteryPercentage
 
+                    val desc =
+                        if (isPeriodic) {
+                            "Periodic battery status check report"
+                        } else {
+                            "Device battery level is critically low"
+                        }
+                    val thresholdLabel = if (isPeriodic) "📊 Configured Threshold" else "⚠️ Alert Threshold"
+
                     buildJsonEmbed(
-                        title = "🪫 Battery Alert",
-                        description = "Device battery level is critically low",
-                        color = COLOR_BATTERY_CRITICAL,
+                        title = if (isPeriodic) "🔋 Battery Status Report" else "🪫 Battery Alert",
+                        description = desc,
+                        color = if (isPeriodic) COLOR_STATUS_REPORT else COLOR_BATTERY_CRITICAL,
                         fields =
                             listOf(
                                 Field("🔋 Current Level", "$currentLevel%"),
-                                Field("⚠️ Alert Threshold", "$threshold%"),
+                                Field(thresholdLabel, "$threshold%"),
                                 Field("📱 Device", deviceName, inline = true),
                                 Field("📍 Android", android.os.Build.VERSION.RELEASE, inline = true),
                             ),
@@ -89,14 +100,22 @@ class DiscordWebhookNotificationSender
                     val currentStorage = remoteAlert.currentStorageGb ?: remoteAlert.storageMinSpaceGb.toDouble()
                     val threshold = remoteAlert.storageMinSpaceGb
 
+                    val desc =
+                        if (isPeriodic) {
+                            "Periodic storage space check report"
+                        } else {
+                            "Available storage space is critically low"
+                        }
+                    val thresholdLabel = if (isPeriodic) "📊 Configured Threshold" else "⚠️ Alert Threshold"
+
                     buildJsonEmbed(
-                        title = "💾 Storage Alert",
-                        description = "Available storage space is critically low",
-                        color = COLOR_STORAGE_CRITICAL,
+                        title = if (isPeriodic) "ℹ️ Storage Status Report" else "💾 Storage Alert",
+                        description = desc,
+                        color = if (isPeriodic) COLOR_STATUS_REPORT else COLOR_STORAGE_CRITICAL,
                         fields =
                             listOf(
                                 Field("💿 Available Space", String.format(Locale.US, "%.1f GB", currentStorage)),
-                                Field("⚠️ Alert Threshold", "$threshold GB"),
+                                Field(thresholdLabel, "$threshold GB"),
                                 Field("📱 Device", deviceName, inline = true),
                                 Field("📍 Android", android.os.Build.VERSION.RELEASE, inline = true),
                             ),

--- a/app/src/main/java/dev/hossain/remotenotify/notifier/MailgunEmailNotificationSender.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/notifier/MailgunEmailNotificationSender.kt
@@ -6,6 +6,7 @@ import dev.hossain.remotenotify.data.ConfigValidationResult
 import dev.hossain.remotenotify.data.EmailConfigDataStore
 import dev.hossain.remotenotify.data.EmailQuotaManager
 import dev.hossain.remotenotify.model.AlertMediumConfig
+import dev.hossain.remotenotify.model.AlertMode
 import dev.hossain.remotenotify.model.DeviceAlert
 import dev.hossain.remotenotify.model.RemoteAlert
 import dev.hossain.remotenotify.model.toTypeDisplayName
@@ -35,6 +36,11 @@ class MailgunEmailNotificationSender
         override val notifierType: NotifierType = NotifierType.EMAIL
 
         override suspend fun sendNotification(remoteAlert: RemoteAlert): Boolean {
+            if (remoteAlert.alertMode == AlertMode.PERIODIC) {
+                Timber.i("Skipping EMAIL notification for PERIODIC alert due to daily quota limit")
+                return true
+            }
+
             if (!emailQuotaManager.canSendEmail()) {
                 Timber.w("Daily email quota exceeded")
                 return false

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlert.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlert.kt
@@ -9,10 +9,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -20,6 +22,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
@@ -39,6 +42,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontStyle
@@ -57,6 +61,7 @@ import com.slack.circuitx.effects.LaunchedImpressionEffect
 import dev.hossain.remotenotify.R
 import dev.hossain.remotenotify.analytics.Analytics
 import dev.hossain.remotenotify.data.AppPreferencesDataStore
+import dev.hossain.remotenotify.data.EmailConfigDataStore
 import dev.hossain.remotenotify.data.RemoteAlertRepository
 import dev.hossain.remotenotify.model.AlertMode
 import dev.hossain.remotenotify.model.AlertType
@@ -85,6 +90,7 @@ data class AddNewRemoteAlertScreen(
         val isBatteryOptimized: Boolean,
         val selectedAlertType: AlertType,
         val selectedAlertMode: AlertMode,
+        val hasEmailConfigured: Boolean = false,
         val threshold: Int,
         val availableStorage: Int,
         val storageSliderMax: Int,
@@ -129,6 +135,7 @@ class AddNewRemoteAlertPresenter
         private val remoteAlertRepository: RemoteAlertRepository,
         private val storageMonitor: StorageMonitor,
         private val appPreferencesDataStore: AppPreferencesDataStore,
+        private val emailConfigDataStore: EmailConfigDataStore,
         private val analytics: Analytics,
     ) : Presenter<AddNewRemoteAlertScreen.State> {
         @Composable
@@ -140,6 +147,7 @@ class AddNewRemoteAlertPresenter
                 mutableStateOf(BatteryOptimizationHelper.isIgnoringBatteryOptimizations(context))
             }
             var hideBatteryOptReminder by remember { mutableStateOf(false) }
+            var hasEmailConfigured by remember { mutableStateOf(false) }
 
             val isEditMode = screen.alertId != null
             var selectedType by remember { mutableStateOf(AlertType.BATTERY) }
@@ -197,8 +205,13 @@ class AddNewRemoteAlertPresenter
             }
 
             LaunchedEffect(Unit) {
-                appPreferencesDataStore.hideBatteryOptReminder.collect { hidden ->
-                    hideBatteryOptReminder = hidden
+                launch {
+                    hasEmailConfigured = emailConfigDataStore.hasValidConfig()
+                }
+                launch {
+                    appPreferencesDataStore.hideBatteryOptReminder.collect { hidden ->
+                        hideBatteryOptReminder = hidden
+                    }
                 }
             }
 
@@ -224,6 +237,7 @@ class AddNewRemoteAlertPresenter
                 isBatteryOptimized = isBatteryOptimized,
                 selectedAlertType = selectedType,
                 selectedAlertMode = selectedMode,
+                hasEmailConfigured = hasEmailConfigured,
                 threshold = threshold,
                 availableStorage = availableStorage,
                 storageSliderMax = storageSliderMax,
@@ -404,6 +418,45 @@ fun AddNewRemoteAlertUi(
                             state.eventSink(AddNewRemoteAlertScreen.Event.UpdateAlertMode(mode))
                         },
                         modifier = Modifier.padding(top = 8.dp),
+                    )
+                }
+            }
+
+            if (state.selectedAlertMode == AlertMode.PERIODIC && state.hasEmailConfigured) {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors =
+                        CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                        ),
+                ) {
+                    ListItem(
+                        colors =
+                            ListItemDefaults.colors(
+                                containerColor = Color.Transparent,
+                            ),
+                        leadingContent = {
+                            Icon(
+                                imageVector = Icons.Default.Info,
+                                contentDescription = null,
+                                modifier = Modifier.size(24.dp),
+                                tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                            )
+                        },
+                        headlineContent = {
+                            Text(
+                                "Email Notifications Skipped",
+                                style = MaterialTheme.typography.titleSmall,
+                                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                            )
+                        },
+                        supportingContent = {
+                            Text(
+                                "Email notify will be skipped for Periodic check mode due to daily email quota limits (max 2/day). Other configured notification mediums will continue to receive periodic updates.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                            )
+                        },
                     )
                 }
             }
@@ -718,6 +771,7 @@ private fun PreviewStorageAlertUi() {
                     isBatteryOptimized = true,
                     selectedAlertType = AlertType.STORAGE,
                     selectedAlertMode = AlertMode.PERIODIC,
+                    hasEmailConfigured = true,
                     threshold = 8,
                     availableStorage = 16,
                     storageSliderMax = 20,

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlert.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlert.kt
@@ -58,6 +58,7 @@ import dev.hossain.remotenotify.R
 import dev.hossain.remotenotify.analytics.Analytics
 import dev.hossain.remotenotify.data.AppPreferencesDataStore
 import dev.hossain.remotenotify.data.RemoteAlertRepository
+import dev.hossain.remotenotify.model.AlertMode
 import dev.hossain.remotenotify.model.AlertType
 import dev.hossain.remotenotify.model.RemoteAlert
 import dev.hossain.remotenotify.model.toAlertType
@@ -83,6 +84,7 @@ data class AddNewRemoteAlertScreen(
         val showBatteryOptSheet: Boolean,
         val isBatteryOptimized: Boolean,
         val selectedAlertType: AlertType,
+        val selectedAlertMode: AlertMode,
         val threshold: Int,
         val availableStorage: Int,
         val storageSliderMax: Int,
@@ -107,6 +109,10 @@ data class AddNewRemoteAlertScreen(
 
         data class UpdateAlertType(
             val alertType: AlertType,
+        ) : Event
+
+        data class UpdateAlertMode(
+            val alertMode: AlertMode,
         ) : Event
 
         data class UpdateThreshold(
@@ -137,6 +143,7 @@ class AddNewRemoteAlertPresenter
 
             val isEditMode = screen.alertId != null
             var selectedType by remember { mutableStateOf(AlertType.BATTERY) }
+            var selectedMode by remember { mutableStateOf(AlertMode.THRESHOLD) }
             var threshold by remember { mutableIntStateOf(10) }
             var existingAlertId by remember { mutableStateOf<Long?>(null) }
 
@@ -169,11 +176,13 @@ class AddNewRemoteAlertPresenter
                     when (existingAlert) {
                         is RemoteAlert.BatteryAlert -> {
                             selectedType = AlertType.BATTERY
+                            selectedMode = existingAlert.alertMode
                             threshold = existingAlert.batteryPercentage
                         }
 
                         is RemoteAlert.StorageAlert -> {
                             selectedType = AlertType.STORAGE
+                            selectedMode = existingAlert.alertMode
                             threshold = existingAlert.storageMinSpaceGb
                         }
                     }
@@ -214,6 +223,7 @@ class AddNewRemoteAlertPresenter
                 showBatteryOptSheet = showBatteryOptimizeSheet,
                 isBatteryOptimized = isBatteryOptimized,
                 selectedAlertType = selectedType,
+                selectedAlertMode = selectedMode,
                 threshold = threshold,
                 availableStorage = availableStorage,
                 storageSliderMax = storageSliderMax,
@@ -282,6 +292,10 @@ class AddNewRemoteAlertPresenter
 
                     is AddNewRemoteAlertScreen.Event.UpdateAlertType -> {
                         selectedType = event.alertType
+                    }
+
+                    is AddNewRemoteAlertScreen.Event.UpdateAlertMode -> {
+                        selectedMode = event.alertMode
                     }
 
                     is AddNewRemoteAlertScreen.Event.UpdateThreshold -> {
@@ -368,7 +382,7 @@ fun AddNewRemoteAlertUi(
                 }
             }
 
-            // Threshold Selection
+            // Alert Mode Selection
             Card(
                 modifier = Modifier.fillMaxWidth(),
                 colors =
@@ -378,43 +392,71 @@ fun AddNewRemoteAlertUi(
             ) {
                 Column(
                     modifier = Modifier.padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     Text(
-                        when (state.selectedAlertType) {
-                            AlertType.BATTERY -> "Battery Level Threshold"
-                            AlertType.STORAGE -> "Storage Space Threshold"
-                        },
+                        "Check Mode",
                         style = MaterialTheme.typography.labelMedium,
                     )
+                    AlertModeSelector(
+                        selectedMode = state.selectedAlertMode,
+                        onModeSelected = { mode ->
+                            state.eventSink(AddNewRemoteAlertScreen.Event.UpdateAlertMode(mode))
+                        },
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                }
+            }
 
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            // Threshold Selection
+            if (state.selectedAlertMode == AlertMode.THRESHOLD) {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors =
+                        CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        ),
+                ) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
                         Text(
                             when (state.selectedAlertType) {
-                                AlertType.BATTERY -> "Alert when battery falls below ${state.threshold}%"
-                                AlertType.STORAGE -> "Alert when available storage is below ${state.threshold}GB"
+                                AlertType.BATTERY -> "Battery Level Threshold"
+                                AlertType.STORAGE -> "Storage Space Threshold"
                             },
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            style = MaterialTheme.typography.labelMedium,
                         )
-                        Slider(
-                            value = state.threshold.toFloat(),
-                            onValueChange = { value ->
-                                state.eventSink(AddNewRemoteAlertScreen.Event.UpdateThreshold(value.toInt()))
-                            },
-                            valueRange =
-                                when (state.selectedAlertType) {
-                                    AlertType.BATTERY -> 5f..50f
-                                    AlertType.STORAGE -> 1f..state.storageSliderMax.toFloat()
-                                },
-                            steps =
-                                when (state.selectedAlertType) {
-                                    AlertType.BATTERY -> 44
 
-                                    // Total steps: (50-5) - 1 = 44 steps
-                                    AlertType.STORAGE -> (state.storageSliderMax - 1) // From 1 to max, so max-1 steps
+                        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            Text(
+                                when (state.selectedAlertType) {
+                                    AlertType.BATTERY -> "Alert when battery falls below ${state.threshold}%"
+                                    AlertType.STORAGE -> "Alert when available storage is below ${state.threshold}GB"
                                 },
-                        )
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Slider(
+                                value = state.threshold.toFloat(),
+                                onValueChange = { value ->
+                                    state.eventSink(AddNewRemoteAlertScreen.Event.UpdateThreshold(value.toInt()))
+                                },
+                                valueRange =
+                                    when (state.selectedAlertType) {
+                                        AlertType.BATTERY -> 5f..50f
+                                        AlertType.STORAGE -> 1f..state.storageSliderMax.toFloat()
+                                    },
+                                steps =
+                                    when (state.selectedAlertType) {
+                                        AlertType.BATTERY -> 44
+
+                                        // Total steps: (50-5) - 1 = 44 steps
+                                        AlertType.STORAGE -> (state.storageSliderMax - 1) // From 1 to max, so max-1 steps
+                                    },
+                            )
+                        }
                     }
                 }
             }
@@ -431,8 +473,19 @@ fun AddNewRemoteAlertUi(
                     headlineContent = {
                         Text(
                             when (state.selectedAlertType) {
-                                AlertType.BATTERY -> "Battery Alert"
-                                AlertType.STORAGE -> "Storage Alert"
+                                AlertType.BATTERY ->
+                                    if (state.selectedAlertMode == AlertMode.PERIODIC) {
+                                        "Battery Status"
+                                    } else {
+                                        "Battery Alert"
+                                    }
+
+                                AlertType.STORAGE ->
+                                    if (state.selectedAlertMode == AlertMode.PERIODIC) {
+                                        "Storage Status"
+                                    } else {
+                                        "Storage Alert"
+                                    }
                             },
                         )
                     },
@@ -441,24 +494,37 @@ fun AddNewRemoteAlertUi(
                             Text(
                                 when (state.selectedAlertType) {
                                     AlertType.BATTERY -> {
-                                        "Will notify when battery is below ${state.threshold}%"
+                                        if (state.selectedAlertMode == AlertMode.PERIODIC) {
+                                            "Will send current battery status every configured check interval"
+                                        } else {
+                                            "Will notify when battery is below ${state.threshold}%"
+                                        }
                                     }
 
                                     AlertType.STORAGE -> {
-                                        buildString {
-                                            append("Will notify when storage is below ${state.threshold}GB")
-                                            append(" (Currently: ${state.availableStorage}GB available)")
+                                        if (state.selectedAlertMode == AlertMode.PERIODIC) {
+                                            buildString {
+                                                append("Will send current storage status every configured check interval")
+                                                append(" (Currently: ${state.availableStorage}GB available)")
+                                            }
+                                        } else {
+                                            buildString {
+                                                append("Will notify when storage is below ${state.threshold}GB")
+                                                append(" (Currently: ${state.availableStorage}GB available)")
+                                            }
                                         }
                                     }
                                 },
                             )
-                            Spacer(modifier = Modifier.height(2.dp))
-                            Text(
-                                "NOTE: Same alert will be sent only once every 24 hours.",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
-                                fontStyle = FontStyle.Italic,
-                            )
+                            if (state.selectedAlertMode == AlertMode.THRESHOLD) {
+                                Spacer(modifier = Modifier.height(2.dp))
+                                Text(
+                                    "NOTE: Same alert will be sent only once every 24 hours.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                                    fontStyle = FontStyle.Italic,
+                                )
+                            }
                         }
                     },
                     leadingContent = {
@@ -479,8 +545,17 @@ fun AddNewRemoteAlertUi(
                 onClick = {
                     val notification =
                         when (state.selectedAlertType) {
-                            AlertType.BATTERY -> RemoteAlert.BatteryAlert(batteryPercentage = state.threshold)
-                            AlertType.STORAGE -> RemoteAlert.StorageAlert(storageMinSpaceGb = state.threshold)
+                            AlertType.BATTERY ->
+                                RemoteAlert.BatteryAlert(
+                                    batteryPercentage = state.threshold,
+                                    alertMode = state.selectedAlertMode,
+                                )
+
+                            AlertType.STORAGE ->
+                                RemoteAlert.StorageAlert(
+                                    storageMinSpaceGb = state.threshold,
+                                    alertMode = state.selectedAlertMode,
+                                )
                         }
                     state.eventSink(AddNewRemoteAlertScreen.Event.SaveNotification(notification))
                 },
@@ -566,6 +641,48 @@ private fun AlertTypeSelector(
 }
 
 @Composable
+private fun AlertModeSelector(
+    selectedMode: AlertMode,
+    onModeSelected: (AlertMode) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SingleChoiceSegmentedButtonRow(modifier = modifier.fillMaxWidth()) {
+        AlertMode.entries.forEachIndexed { index, alertMode ->
+            SegmentedButton(
+                shape =
+                    SegmentedButtonDefaults.itemShape(
+                        index = index,
+                        count = AlertMode.entries.size,
+                    ),
+                icon = {
+                    SegmentedButtonDefaults.Icon(active = alertMode == selectedMode) {
+                        Icon(
+                            painter =
+                                painterResource(
+                                    when (alertMode) {
+                                        AlertMode.THRESHOLD -> R.drawable.notification_settings_24dp
+                                        AlertMode.PERIODIC -> R.drawable.schedule_24dp
+                                    },
+                                ),
+                            contentDescription = null,
+                        )
+                    }
+                },
+                onClick = { onModeSelected(alertMode) },
+                selected = alertMode == selectedMode,
+            ) {
+                Text(
+                    when (alertMode) {
+                        AlertMode.THRESHOLD -> "Threshold"
+                        AlertMode.PERIODIC -> "Periodic"
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
 @PreviewLightDark
 @PreviewDynamicColors
 private fun PreviewAddNewRemoteAlertUi() {
@@ -577,6 +694,7 @@ private fun PreviewAddNewRemoteAlertUi() {
                     showBatteryOptSheet = false,
                     isBatteryOptimized = false,
                     selectedAlertType = AlertType.BATTERY,
+                    selectedAlertMode = AlertMode.THRESHOLD,
                     threshold = 10,
                     availableStorage = 56,
                     storageSliderMax = 96,
@@ -599,6 +717,7 @@ private fun PreviewStorageAlertUi() {
                     showBatteryOptSheet = false,
                     isBatteryOptimized = true,
                     selectedAlertType = AlertType.STORAGE,
+                    selectedAlertMode = AlertMode.PERIODIC,
                     threshold = 8,
                     availableStorage = 16,
                     storageSliderMax = 20,
@@ -621,6 +740,7 @@ private fun PreviewEditAlertUi() {
                     showBatteryOptSheet = false,
                     isBatteryOptimized = true,
                     selectedAlertType = AlertType.BATTERY,
+                    selectedAlertMode = AlertMode.THRESHOLD,
                     threshold = 20,
                     availableStorage = 56,
                     storageSliderMax = 96,

--- a/app/src/main/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlert.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/addalert/AddNewRemoteAlert.kt
@@ -526,19 +526,21 @@ fun AddNewRemoteAlertUi(
                     headlineContent = {
                         Text(
                             when (state.selectedAlertType) {
-                                AlertType.BATTERY ->
+                                AlertType.BATTERY -> {
                                     if (state.selectedAlertMode == AlertMode.PERIODIC) {
                                         "Battery Status"
                                     } else {
                                         "Battery Alert"
                                     }
+                                }
 
-                                AlertType.STORAGE ->
+                                AlertType.STORAGE -> {
                                     if (state.selectedAlertMode == AlertMode.PERIODIC) {
                                         "Storage Status"
                                     } else {
                                         "Storage Alert"
                                     }
+                                }
                             },
                         )
                     },
@@ -598,17 +600,19 @@ fun AddNewRemoteAlertUi(
                 onClick = {
                     val notification =
                         when (state.selectedAlertType) {
-                            AlertType.BATTERY ->
+                            AlertType.BATTERY -> {
                                 RemoteAlert.BatteryAlert(
                                     batteryPercentage = state.threshold,
                                     alertMode = state.selectedAlertMode,
                                 )
+                            }
 
-                            AlertType.STORAGE ->
+                            AlertType.STORAGE -> {
                                 RemoteAlert.StorageAlert(
                                     storageMinSpaceGb = state.threshold,
                                     alertMode = state.selectedAlertMode,
                                 )
+                            }
                         }
                     state.eventSink(AddNewRemoteAlertScreen.Event.SaveNotification(notification))
                 },

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
@@ -61,6 +61,7 @@ import dev.hossain.remotenotify.analytics.Analytics
 import dev.hossain.remotenotify.data.AppPreferencesDataStore
 import dev.hossain.remotenotify.data.RemoteAlertRepository
 import dev.hossain.remotenotify.model.AlertCheckLog
+import dev.hossain.remotenotify.model.AlertMode
 import dev.hossain.remotenotify.model.AlertType
 import dev.hossain.remotenotify.model.RemoteAlert
 import dev.hossain.remotenotify.model.WorkerStatus
@@ -497,8 +498,19 @@ fun NotificationItem(
             Text(
                 text =
                     when (remoteAlert) {
-                        is RemoteAlert.BatteryAlert -> "Battery Alert"
-                        is RemoteAlert.StorageAlert -> "Storage Alert"
+                        is RemoteAlert.BatteryAlert ->
+                            if (remoteAlert.alertMode == AlertMode.PERIODIC) {
+                                "Battery Status"
+                            } else {
+                                "Battery Alert"
+                            }
+
+                        is RemoteAlert.StorageAlert ->
+                            if (remoteAlert.alertMode == AlertMode.PERIODIC) {
+                                "Storage Status"
+                            } else {
+                                "Storage Alert"
+                            }
                     },
                 style = MaterialTheme.typography.titleSmall,
             )
@@ -510,23 +522,35 @@ fun NotificationItem(
             ) {
                 when (remoteAlert) {
                     is RemoteAlert.BatteryAlert -> {
-                        LinearProgressIndicator(
-                            progress = { remoteAlert.batteryPercentage / 100f },
-                            modifier =
-                                Modifier
-                                    .weight(1f)
-                                    .height(4.dp),
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = "${remoteAlert.batteryPercentage}%",
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
+                        if (remoteAlert.alertMode == AlertMode.PERIODIC) {
+                            Text(
+                                text = "Sends current battery status every check interval",
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        } else {
+                            LinearProgressIndicator(
+                                progress = { remoteAlert.batteryPercentage / 100f },
+                                modifier =
+                                    Modifier
+                                        .weight(1f)
+                                        .height(4.dp),
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = "${remoteAlert.batteryPercentage}%",
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
+                        }
                     }
 
                     is RemoteAlert.StorageAlert -> {
                         Text(
-                            text = "Min Storage: ${remoteAlert.storageMinSpaceGb} GB",
+                            text =
+                                if (remoteAlert.alertMode == AlertMode.PERIODIC) {
+                                    "Sends current storage status every check interval"
+                                } else {
+                                    "Min Storage: ${remoteAlert.storageMinSpaceGb} GB"
+                                },
                             style = MaterialTheme.typography.bodyMedium,
                         )
                     }

--- a/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/ui/alertlist/AlertsListScreen.kt
@@ -498,19 +498,21 @@ fun NotificationItem(
             Text(
                 text =
                     when (remoteAlert) {
-                        is RemoteAlert.BatteryAlert ->
+                        is RemoteAlert.BatteryAlert -> {
                             if (remoteAlert.alertMode == AlertMode.PERIODIC) {
                                 "Battery Status"
                             } else {
                                 "Battery Alert"
                             }
+                        }
 
-                        is RemoteAlert.StorageAlert ->
+                        is RemoteAlert.StorageAlert -> {
                             if (remoteAlert.alertMode == AlertMode.PERIODIC) {
                                 "Storage Status"
                             } else {
                                 "Storage Alert"
                             }
+                        }
                     },
                 style = MaterialTheme.typography.titleSmall,
             )

--- a/app/src/main/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorker.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorker.kt
@@ -156,6 +156,11 @@ class ObserveDeviceHealthWorker(
         notifiers
             .filter { it.hasValidConfig() }
             .forEach { notifier ->
+                if (remoteAlert.alertMode == AlertMode.PERIODIC && notifier.notifierType == NotifierType.EMAIL) {
+                    Timber.tag(WORKER_LOG_TAG).i("Skipping EMAIL notification for PERIODIC alert due to daily quota limit")
+                    return@forEach
+                }
+
                 try {
                     Timber.tag(WORKER_LOG_TAG).i("Sending notification with ${notifier.notifierType}")
 

--- a/app/src/main/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorker.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorker.kt
@@ -7,6 +7,7 @@ import androidx.work.workDataOf
 import dev.hossain.remotenotify.analytics.Analytics
 import dev.hossain.remotenotify.data.RemoteAlertRepository
 import dev.hossain.remotenotify.model.AlertCheckLog
+import dev.hossain.remotenotify.model.AlertMode
 import dev.hossain.remotenotify.model.AlertType
 import dev.hossain.remotenotify.model.RemoteAlert
 import dev.hossain.remotenotify.monitor.BatteryMonitor
@@ -61,22 +62,15 @@ class ObserveDeviceHealthWorker(
 
             // Send notifications if thresholds are met
             userConfiguredAlerts.forEach { userConfiguredAlert: RemoteAlert ->
-                val lastAlertLog: AlertCheckLog? = repository.getLatestCheckForAlert(userConfiguredAlert.alertId).first()
-
-                // Skip if last alert was triggered within 24 hours
-                if (lastAlertLog?.isAlertSent == true) {
-                    val hoursSinceLastAlert = (System.currentTimeMillis() - lastAlertLog.checkedOn) / (1000 * 60 * 60)
-                    if (hoursSinceLastAlert < 24) {
-                        // NOTE: This is to avoid spamming the notification
-                        // If the 24 hour limit changes, make sure to update `Add Alert` screen to reflect that.
-                        Timber.tag(WORKER_LOG_TAG).d("Skipping alert: Last notification was sent $hoursSinceLastAlert hours ago")
-                        return@forEach
-                    }
+                if (userConfiguredAlert.alertMode == AlertMode.THRESHOLD && wasThresholdAlertSentRecently(userConfiguredAlert)) {
+                    return@forEach
                 }
 
                 when (userConfiguredAlert) {
                     is RemoteAlert.BatteryAlert -> {
-                        val triggered = deviceCurrentBatteryLevel <= userConfiguredAlert.batteryPercentage
+                        val triggered =
+                            userConfiguredAlert.alertMode == AlertMode.PERIODIC ||
+                                deviceCurrentBatteryLevel <= userConfiguredAlert.batteryPercentage
                         checkAndProcessAlert(
                             userConfiguredAlert = userConfiguredAlert,
                             triggered = triggered,
@@ -86,7 +80,9 @@ class ObserveDeviceHealthWorker(
                     }
 
                     is RemoteAlert.StorageAlert -> {
-                        val triggered = deviceCurrentAvailableStorage <= userConfiguredAlert.storageMinSpaceGb
+                        val triggered =
+                            userConfiguredAlert.alertMode == AlertMode.PERIODIC ||
+                                deviceCurrentAvailableStorage <= userConfiguredAlert.storageMinSpaceGb
                         checkAndProcessAlert(
                             userConfiguredAlert = userConfiguredAlert,
                             triggered = triggered,
@@ -112,6 +108,23 @@ class ObserveDeviceHealthWorker(
 
             return Result.failure()
         }
+    }
+
+    private suspend fun wasThresholdAlertSentRecently(userConfiguredAlert: RemoteAlert): Boolean {
+        val lastAlertLog: AlertCheckLog? = repository.getLatestCheckForAlert(userConfiguredAlert.alertId).first()
+
+        // Skip if last alert was triggered within 24 hours
+        if (lastAlertLog?.isAlertSent == true) {
+            val hoursSinceLastAlert = (System.currentTimeMillis() - lastAlertLog.checkedOn) / (1000 * 60 * 60)
+            if (hoursSinceLastAlert < 24) {
+                // NOTE: This is to avoid spamming threshold notifications.
+                // Periodic alerts intentionally send once per configured worker interval.
+                Timber.tag(WORKER_LOG_TAG).d("Skipping alert: Last notification was sent $hoursSinceLastAlert hours ago")
+                return true
+            }
+        }
+
+        return false
     }
 
     private suspend fun checkAndProcessAlert(
@@ -156,6 +169,7 @@ class ObserveDeviceHealthWorker(
                                     alertId = remoteAlert.alertId,
                                     batteryPercentage = remoteAlert.batteryPercentage, // Threshold from DB
                                     currentBatteryLevel = stateValue, // Current measured battery level
+                                    alertMode = remoteAlert.alertMode,
                                 )
                             }
 
@@ -164,6 +178,7 @@ class ObserveDeviceHealthWorker(
                                     alertId = remoteAlert.alertId,
                                     storageMinSpaceGb = remoteAlert.storageMinSpaceGb, // Threshold from DB
                                     currentStorageGb = stateValue.toDouble(), // Current measured storage
+                                    alertMode = remoteAlert.alertMode,
                                 )
                             }
                         }

--- a/app/src/main/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorker.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorker.kt
@@ -158,6 +158,7 @@ class ObserveDeviceHealthWorker(
             .forEach { notifier ->
                 if (remoteAlert.alertMode == AlertMode.PERIODIC && notifier.notifierType == NotifierType.EMAIL) {
                     Timber.tag(WORKER_LOG_TAG).i("Skipping EMAIL notification for PERIODIC alert due to daily quota limit")
+                    saveAlertCheckLog(remoteAlert.alertId, alertType, stateValue, false, notifier.notifierType)
                     return@forEach
                 }
 

--- a/app/src/test/java/dev/hossain/remotenotify/data/AlertFormatterTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/data/AlertFormatterTest.kt
@@ -1,5 +1,6 @@
 package dev.hossain.remotenotify.data
 
+import dev.hossain.remotenotify.model.AlertMode
 import dev.hossain.remotenotify.model.DeviceAlert
 import dev.hossain.remotenotify.model.RemoteAlert
 import org.junit.Assert.assertTrue
@@ -182,5 +183,45 @@ class AlertFormatterTest {
         // Then
         assertTrue("Should contain battery percentage", result.contains("15%"))
         assertTrue("Should contain critical low message", result.contains("critically low"))
+    }
+
+    @Test
+    fun `periodic battery status with current level does not show threshold`() {
+        // Given
+        val batteryAlert =
+            RemoteAlert.BatteryAlert(
+                alertId = 1L,
+                batteryPercentage = 15,
+                currentBatteryLevel = 80,
+                alertMode = AlertMode.PERIODIC,
+            )
+
+        // When
+        val result = alertFormatter.format(batteryAlert, DeviceAlert.FormatType.TEXT)
+
+        // Then
+        assertTrue("Should contain current battery level", result.contains("Battery Level: 80%"))
+        assertTrue("Should not contain threshold value", !result.contains("Threshold:"))
+        assertTrue("Should not indicate critical status", !result.contains("Critical"))
+    }
+
+    @Test
+    fun `periodic storage status with current storage does not show threshold`() {
+        // Given
+        val storageAlert =
+            RemoteAlert.StorageAlert(
+                alertId = 1L,
+                storageMinSpaceGb = 10,
+                currentStorageGb = 42.0,
+                alertMode = AlertMode.PERIODIC,
+            )
+
+        // When
+        val result = alertFormatter.format(storageAlert, DeviceAlert.FormatType.TEXT)
+
+        // Then
+        assertTrue("Should contain current storage value", result.contains("Storage Space Available: 42.0 GB"))
+        assertTrue("Should not contain threshold value", !result.contains("Threshold:"))
+        assertTrue("Should not indicate critical status", !result.contains("Critical"))
     }
 }

--- a/app/src/test/java/dev/hossain/remotenotify/data/export/AppConfigurationTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/data/export/AppConfigurationTest.kt
@@ -1,6 +1,7 @@
 package dev.hossain.remotenotify.data.export
 
 import com.google.common.truth.Truth.assertThat
+import dev.hossain.remotenotify.model.AlertMode
 import dev.hossain.remotenotify.model.AlertType
 import org.junit.Test
 
@@ -16,6 +17,7 @@ class AppConfigurationTest {
         assertThat(alertConfig.type).isEqualTo(AlertType.BATTERY)
         assertThat(alertConfig.batteryPercentage).isEqualTo(20)
         assertThat(alertConfig.storageMinSpaceGb).isNull()
+        assertThat(alertConfig.alertMode).isEqualTo(AlertMode.THRESHOLD)
     }
 
     @Test
@@ -24,11 +26,13 @@ class AppConfigurationTest {
             AlertConfig(
                 type = AlertType.STORAGE,
                 storageMinSpaceGb = 5,
+                alertMode = AlertMode.PERIODIC,
             )
 
         assertThat(alertConfig.type).isEqualTo(AlertType.STORAGE)
         assertThat(alertConfig.storageMinSpaceGb).isEqualTo(5)
         assertThat(alertConfig.batteryPercentage).isNull()
+        assertThat(alertConfig.alertMode).isEqualTo(AlertMode.PERIODIC)
     }
 
     @Test

--- a/app/src/test/java/dev/hossain/remotenotify/data/export/ConfigurationImporterValidationTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/data/export/ConfigurationImporterValidationTest.kt
@@ -13,6 +13,7 @@ import dev.hossain.remotenotify.data.SlackWebhookConfigDataStore
 import dev.hossain.remotenotify.data.TelegramConfigDataStore
 import dev.hossain.remotenotify.data.TwilioConfigDataStore
 import dev.hossain.remotenotify.data.WebhookConfigDataStore
+import dev.hossain.remotenotify.model.AlertMode
 import dev.hossain.remotenotify.model.AlertType
 import io.mockk.mockk
 import org.junit.Before
@@ -150,6 +151,37 @@ class ConfigurationImporterValidationTest {
         assertThat(result).isInstanceOf(ImportValidationResult.Invalid::class.java)
         val invalid = result as ImportValidationResult.Invalid
         assertThat(invalid.errors.any { it.contains("storageMinSpaceGb") }).isTrue()
+    }
+
+    @Test
+    fun `parseAndValidate returns Valid for periodic alerts without thresholds`() {
+        val json =
+            """
+            {
+                "version": 2,
+                "exportedAt": 1234567890,
+                "alerts": [
+                    {
+                        "type": "BATTERY",
+                        "alertMode": "PERIODIC"
+                    },
+                    {
+                        "type": "STORAGE",
+                        "alertMode": "PERIODIC"
+                    }
+                ],
+                "notifiers": {},
+                "preferences": {}
+            }
+            """.trimIndent()
+
+        val result = importer.parseAndValidate(json)
+
+        assertThat(result).isInstanceOf(ImportValidationResult.Valid::class.java)
+        val valid = result as ImportValidationResult.Valid
+        assertThat(valid.configuration.alerts).hasSize(2)
+        assertThat(valid.configuration.alerts[0].alertMode).isEqualTo(AlertMode.PERIODIC)
+        assertThat(valid.configuration.alerts[1].alertMode).isEqualTo(AlertMode.PERIODIC)
     }
 
     @Test

--- a/app/src/test/java/dev/hossain/remotenotify/model/DeviceAlertTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/model/DeviceAlertTest.kt
@@ -47,7 +47,7 @@ class DeviceAlertTest {
 
         val result = alert.format(DeviceAlert.FormatType.TEXT)
 
-        assertThat(result).contains("Battery Level is at 10%")
+        assertThat(result).contains("Battery Level: 10%")
     }
 
     @Test
@@ -153,12 +153,14 @@ class DeviceAlertTest {
                 deviceModel = "Pixel 7",
                 androidVersion = "14",
                 batteryLevel = 5,
+                isStatusReport = true,
                 timestamp = fixedTimestamp,
             )
 
         val result = alert.format(DeviceAlert.FormatType.EXTENDED_TEXT)
 
-        assertThat(result).contains("critically low at 5%")
+        assertThat(result).contains("Device battery level is 5%")
+        assertThat(result).contains("No action required.")
     }
 
     @Test
@@ -208,12 +210,14 @@ class DeviceAlertTest {
                 deviceModel = "Galaxy S23",
                 androidVersion = "13",
                 availableStorageGb = 8.5,
+                isStatusReport = true,
                 timestamp = fixedTimestamp,
             )
 
         val result = alert.format(DeviceAlert.FormatType.EXTENDED_TEXT)
 
-        assertThat(result).contains("Available storage space is low (8.5 GB)")
+        assertThat(result).contains("Available storage space is 8.5 GB")
+        assertThat(result).contains("No action required.")
     }
 
     @Test

--- a/app/src/test/java/dev/hossain/remotenotify/model/DeviceAlertTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/model/DeviceAlertTest.kt
@@ -375,4 +375,22 @@ class DeviceAlertTest {
 
         assertThat(result).contains("💾")
     }
+
+    @Test
+    fun `status report formats headers appropriately`() {
+        val alert =
+            DeviceAlert(
+                alertType = AlertType.BATTERY,
+                deviceBrand = "Google",
+                deviceModel = "Pixel 7",
+                androidVersion = "14",
+                batteryLevel = 80,
+                isStatusReport = true,
+                timestamp = fixedTimestamp,
+            )
+
+        assertThat(alert.format(DeviceAlert.FormatType.TEXT)).contains("ℹ️ Battery Status Report")
+        assertThat(alert.format(DeviceAlert.FormatType.EXTENDED_TEXT)).contains("ℹ️ Status Report: Battery")
+        assertThat(alert.format(DeviceAlert.FormatType.HTML)).contains("ℹ️ Battery Status Report")
+    }
 }

--- a/app/src/test/java/dev/hossain/remotenotify/model/RemoteAlertTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/model/RemoteAlertTest.kt
@@ -17,17 +17,19 @@ class RemoteAlertTest {
         assertThat(entity.batteryPercentage).isEqualTo(20)
         assertThat(entity.type).isEqualTo(AlertType.BATTERY)
         assertThat(entity.storageMinSpaceGb).isEqualTo(0)
+        assertThat(entity.alertMode).isEqualTo(AlertMode.THRESHOLD)
     }
 
     @Test
     fun `given storage alert, when toAlertConfigEntity, then returns correct entity`() {
-        val storageAlert = RemoteAlert.StorageAlert(alertId = 2L, storageMinSpaceGb = 5)
+        val storageAlert = RemoteAlert.StorageAlert(alertId = 2L, storageMinSpaceGb = 5, alertMode = AlertMode.PERIODIC)
         val entity: AlertConfigEntity = storageAlert.toAlertConfigEntity()
 
         assertThat(entity.id).isEqualTo(2L)
         assertThat(entity.storageMinSpaceGb).isEqualTo(5)
         assertThat(entity.type).isEqualTo(AlertType.STORAGE)
         assertThat(entity.batteryPercentage).isEqualTo(0)
+        assertThat(entity.alertMode).isEqualTo(AlertMode.PERIODIC)
     }
 
     @Test
@@ -70,6 +72,7 @@ class RemoteAlertTest {
                 batteryPercentage = 20,
                 type = AlertType.BATTERY,
                 storageMinSpaceGb = 0,
+                alertMode = AlertMode.PERIODIC,
             )
         val remoteAlert = entity.toRemoteAlert()
 
@@ -77,6 +80,7 @@ class RemoteAlertTest {
         val batteryAlert = remoteAlert as RemoteAlert.BatteryAlert
         assertThat(batteryAlert.alertId).isEqualTo(1L)
         assertThat(batteryAlert.batteryPercentage).isEqualTo(20)
+        assertThat(batteryAlert.alertMode).isEqualTo(AlertMode.PERIODIC)
     }
 
     @Test
@@ -94,5 +98,6 @@ class RemoteAlertTest {
         val storageAlert = remoteAlert as RemoteAlert.StorageAlert
         assertThat(storageAlert.alertId).isEqualTo(2L)
         assertThat(storageAlert.storageMinSpaceGb).isEqualTo(5)
+        assertThat(storageAlert.alertMode).isEqualTo(AlertMode.THRESHOLD)
     }
 }

--- a/app/src/test/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorkerTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorkerTest.kt
@@ -223,6 +223,7 @@ class ObserveDeviceHealthWorkerTest {
             // Then
             assertEquals(ListenableWorker.Result.success(), result)
             coVerify(exactly = 0) { notificationSender.sendNotification(any()) }
+            coVerify { repository.insertAlertCheckLog(1L, AlertType.BATTERY, 80, false, NotifierType.EMAIL) }
         }
 
     @Ignore("Test has incomplete mock setup - repository.insertAlertCheckLog needs proper mocking")

--- a/app/src/test/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorkerTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorkerTest.kt
@@ -7,6 +7,7 @@ import androidx.work.WorkerParameters
 import dev.hossain.remotenotify.analytics.Analytics
 import dev.hossain.remotenotify.data.RemoteAlertRepository
 import dev.hossain.remotenotify.model.AlertCheckLog
+import dev.hossain.remotenotify.model.AlertMode
 import dev.hossain.remotenotify.model.AlertType
 import dev.hossain.remotenotify.model.RemoteAlert
 import dev.hossain.remotenotify.monitor.BatteryMonitor
@@ -76,6 +77,7 @@ class ObserveDeviceHealthWorkerTest {
         coEvery { analytics.logWorkSuccess() } just Runs
         coEvery { analytics.logWorkFailed(any(), any()) } just Runs
         coEvery { analytics.logAlertSent(any(), any()) } just Runs
+        coEvery { repository.insertAlertCheckLog(any(), any(), any(), any(), any()) } just Runs
 
         // Add this to suppress errors from worker params
         every { workerParameters.runAttemptCount } returns 0
@@ -172,6 +174,32 @@ class ObserveDeviceHealthWorkerTest {
             coVerify { repository.insertAlertCheckLog(1L, AlertType.BATTERY, 15, true, NotifierType.EMAIL) }
         }
 
+    @Test
+    fun `doWork sends periodic battery status when threshold is not met`() =
+        runTest {
+            // Given
+            val batteryAlert =
+                RemoteAlert.BatteryAlert(
+                    alertId = 1L,
+                    batteryPercentage = 20,
+                    alertMode = AlertMode.PERIODIC,
+                )
+
+            coEvery { repository.getAllRemoteAlert() } returns listOf(batteryAlert)
+            every { batteryMonitor.getBatteryLevel() } returns 80
+            every { storageMonitor.getAvailableStorageInGB() } returns 20L
+
+            // When
+            val result = worker.doWork()
+
+            // Then
+            val statusAlert = batteryAlert.copy(currentBatteryLevel = 80)
+            assertEquals(ListenableWorker.Result.success(), result)
+            coVerify { notificationSender.sendNotification(statusAlert) }
+            coVerify(exactly = 0) { repository.getLatestCheckForAlert(any()) }
+            coVerify { repository.insertAlertCheckLog(1L, AlertType.BATTERY, 80, true, NotifierType.EMAIL) }
+        }
+
     @Ignore("Test has incomplete mock setup - repository.insertAlertCheckLog needs proper mocking")
     @Test
     fun `doWork logs storage check but doesn't notify when threshold not met`() =
@@ -228,6 +256,32 @@ class ObserveDeviceHealthWorkerTest {
                     notifierType = NotifierType.EMAIL,
                 )
             }
+        }
+
+    @Test
+    fun `doWork sends periodic storage status when threshold is not met`() =
+        runTest {
+            // Given
+            val storageAlert =
+                RemoteAlert.StorageAlert(
+                    alertId = 2L,
+                    storageMinSpaceGb = 10,
+                    alertMode = AlertMode.PERIODIC,
+                )
+
+            coEvery { repository.getAllRemoteAlert() } returns listOf(storageAlert)
+            every { batteryMonitor.getBatteryLevel() } returns 80
+            every { storageMonitor.getAvailableStorageInGB() } returns 42L
+
+            // When
+            val result = worker.doWork()
+
+            // Then
+            val statusAlert = storageAlert.copy(currentStorageGb = 42.0)
+            assertEquals(ListenableWorker.Result.success(), result)
+            coVerify { notificationSender.sendNotification(statusAlert) }
+            coVerify(exactly = 0) { repository.getLatestCheckForAlert(any()) }
+            coVerify { repository.insertAlertCheckLog(2L, AlertType.STORAGE, 42, true, NotifierType.EMAIL) }
         }
 
     @Test

--- a/app/src/test/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorkerTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorkerTest.kt
@@ -178,6 +178,7 @@ class ObserveDeviceHealthWorkerTest {
     fun `doWork sends periodic battery status when threshold is not met`() =
         runTest {
             // Given
+            every { notificationSender.notifierType } returns NotifierType.TELEGRAM
             val batteryAlert =
                 RemoteAlert.BatteryAlert(
                     alertId = 1L,
@@ -197,7 +198,31 @@ class ObserveDeviceHealthWorkerTest {
             assertEquals(ListenableWorker.Result.success(), result)
             coVerify { notificationSender.sendNotification(statusAlert) }
             coVerify(exactly = 0) { repository.getLatestCheckForAlert(any()) }
-            coVerify { repository.insertAlertCheckLog(1L, AlertType.BATTERY, 80, true, NotifierType.EMAIL) }
+            coVerify { repository.insertAlertCheckLog(1L, AlertType.BATTERY, 80, true, NotifierType.TELEGRAM) }
+        }
+
+    @Test
+    fun `doWork skips email notification when alert mode is periodic`() =
+        runTest {
+            // Given
+            every { notificationSender.notifierType } returns NotifierType.EMAIL
+            val batteryAlert =
+                RemoteAlert.BatteryAlert(
+                    alertId = 1L,
+                    batteryPercentage = 20,
+                    alertMode = AlertMode.PERIODIC,
+                )
+
+            coEvery { repository.getAllRemoteAlert() } returns listOf(batteryAlert)
+            every { batteryMonitor.getBatteryLevel() } returns 80
+            every { storageMonitor.getAvailableStorageInGB() } returns 20L
+
+            // When
+            val result = worker.doWork()
+
+            // Then
+            assertEquals(ListenableWorker.Result.success(), result)
+            coVerify(exactly = 0) { notificationSender.sendNotification(any()) }
         }
 
     @Ignore("Test has incomplete mock setup - repository.insertAlertCheckLog needs proper mocking")
@@ -262,6 +287,7 @@ class ObserveDeviceHealthWorkerTest {
     fun `doWork sends periodic storage status when threshold is not met`() =
         runTest {
             // Given
+            every { notificationSender.notifierType } returns NotifierType.TELEGRAM
             val storageAlert =
                 RemoteAlert.StorageAlert(
                     alertId = 2L,
@@ -281,7 +307,7 @@ class ObserveDeviceHealthWorkerTest {
             assertEquals(ListenableWorker.Result.success(), result)
             coVerify { notificationSender.sendNotification(statusAlert) }
             coVerify(exactly = 0) { repository.getLatestCheckForAlert(any()) }
-            coVerify { repository.insertAlertCheckLog(2L, AlertType.STORAGE, 42, true, NotifierType.EMAIL) }
+            coVerify { repository.insertAlertCheckLog(2L, AlertType.STORAGE, 42, true, NotifierType.TELEGRAM) }
         }
 
     @Test


### PR DESCRIPTION
## Summary
- Add an alert mode for threshold-based alerts vs periodic status reports
- Send current battery or storage status on each configured worker interval when periodic mode is selected
- Persist alert mode in Room, export/import configuration, and the add/edit/list alert UI
- Keep existing threshold alerts backward-compatible with 24-hour duplicate suppression

## Verification
- `./gradlew testDebugUnitTest` passed in Docker using `ghcr.io/cirruslabs/android-sdk:36` on linux/amd64
- `./gradlew assembleDebug` passed in Docker
- `./gradlew assembleRelease` passed in Docker with the local debug-keystore fallback used when release keystore secrets are unavailable