### PR TITLE
Fix #453: Harden periodic status report logging, webhook payload alertMode, and rate limiting

### DIFF
--- a/app/schemas/dev.hossain.remotenotify.db.AppDatabase/4.json
+++ b/app/schemas/dev.hossain.remotenotify.db.AppDatabase/4.json
@@ -1,0 +1,148 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "bbd0311cdfef0304abb717d2b700c210",
+    "entities": [
+      {
+        "tableName": "alert_config",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `battery_percentage` INTEGER NOT NULL DEFAULT -1, `storage_min_space_gb` INTEGER NOT NULL DEFAULT -1, `alert_mode` TEXT NOT NULL DEFAULT 'THRESHOLD', `created_on` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "batteryPercentage",
+            "columnName": "battery_percentage",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "storageMinSpaceGb",
+            "columnName": "storage_min_space_gb",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "-1"
+          },
+          {
+            "fieldPath": "alertMode",
+            "columnName": "alert_mode",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'THRESHOLD'"
+          },
+          {
+            "fieldPath": "createdOn",
+            "columnName": "created_on",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "alert_check_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `alert_config_id` INTEGER NOT NULL, `checked_at` INTEGER NOT NULL, `alert_state_value` INTEGER NOT NULL, `is_alert_triggered` INTEGER NOT NULL, `alert_type` TEXT NOT NULL, `notifier_type` TEXT, `alert_mode` TEXT NOT NULL DEFAULT 'THRESHOLD', FOREIGN KEY(`alert_config_id`) REFERENCES `alert_config`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertConfigId",
+            "columnName": "alert_config_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "checkedAt",
+            "columnName": "checked_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertStateValue",
+            "columnName": "alert_state_value",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertTriggered",
+            "columnName": "is_alert_triggered",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "alertType",
+            "columnName": "alert_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notifierType",
+            "columnName": "notifier_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "alertMode",
+            "columnName": "alert_mode",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'THRESHOLD'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_alert_check_log_alert_config_id",
+            "unique": false,
+            "columnNames": [
+              "alert_config_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_alert_check_log_alert_config_id` ON `${TABLE_NAME}` (`alert_config_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "alert_config",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "alert_config_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bbd0311cdfef0304abb717d2b700c210')"
+    ]
+  }
+}

--- a/app/src/main/java/dev/hossain/remotenotify/data/AlertFormatter.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/AlertFormatter.kt
@@ -47,7 +47,7 @@ class AlertFormatter
                                 } else {
                                     null
                                 },
-                            isStatusReport = remoteAlert.alertMode == AlertMode.PERIODIC,
+                            alertMode = remoteAlert.alertMode,
                         )
                     }
 
@@ -65,7 +65,7 @@ class AlertFormatter
                                 } else {
                                     null
                                 },
-                            isStatusReport = remoteAlert.alertMode == AlertMode.PERIODIC,
+                            alertMode = remoteAlert.alertMode,
                         )
                     }
                 }

--- a/app/src/main/java/dev/hossain/remotenotify/data/RemoteAlertRepository.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/data/RemoteAlertRepository.kt
@@ -5,6 +5,7 @@ import dev.hossain.remotenotify.db.AlertCheckLogEntity
 import dev.hossain.remotenotify.db.AlertConfigDao
 import dev.hossain.remotenotify.db.AlertConfigEntity
 import dev.hossain.remotenotify.model.AlertCheckLog
+import dev.hossain.remotenotify.model.AlertMode
 import dev.hossain.remotenotify.model.AlertType
 import dev.hossain.remotenotify.model.RemoteAlert
 import dev.hossain.remotenotify.model.toAlertCheckLog
@@ -49,6 +50,7 @@ interface RemoteAlertRepository {
         alertStateValue: Int,
         alertTriggered: Boolean,
         notifierType: NotifierType?,
+        alertMode: AlertMode = AlertMode.THRESHOLD,
     )
 
     fun getLatestCheckForAlert(alertId: Long): Flow<AlertCheckLog?>
@@ -104,8 +106,9 @@ class RemoteAlertRepositoryImpl
             alertStateValue: Int,
             alertTriggered: Boolean,
             notifierType: NotifierType?,
+            alertMode: AlertMode,
         ) {
-            Timber.d("Inserting alert check log for alertId=$alertId, type=$alertType, triggered=$alertTriggered")
+            Timber.d("Inserting alert check log for alertId=$alertId, type=$alertType, triggered=$alertTriggered, mode=$alertMode")
             alertCheckLogDao.insert(
                 AlertCheckLogEntity(
                     alertConfigId = alertId,
@@ -113,6 +116,7 @@ class RemoteAlertRepositoryImpl
                     alertStateValue = alertStateValue,
                     alertTriggered = alertTriggered,
                     notifierType = notifierType,
+                    alertMode = alertMode,
                 ),
             )
         }

--- a/app/src/main/java/dev/hossain/remotenotify/db/AlertCheckLogDao.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/db/AlertCheckLogDao.kt
@@ -23,7 +23,7 @@ interface AlertCheckLogDao {
         """
         SELECT * FROM alert_check_log 
         WHERE alert_config_id = :alertConfigId 
-        ORDER BY checked_at DESC 
+        ORDER BY checked_at DESC, is_alert_triggered DESC
         LIMIT 1
     """,
     )
@@ -53,7 +53,7 @@ interface AlertCheckLogDao {
     @Query(
         """
         SELECT * FROM alert_check_log 
-        ORDER BY checked_at DESC 
+        ORDER BY checked_at DESC, is_alert_triggered DESC
         LIMIT 1
     """,
     )

--- a/app/src/main/java/dev/hossain/remotenotify/db/AlertCheckLogEntity.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/db/AlertCheckLogEntity.kt
@@ -5,6 +5,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import dev.hossain.remotenotify.model.AlertMode
 import dev.hossain.remotenotify.model.AlertType
 import dev.hossain.remotenotify.notifier.NotifierType
 
@@ -35,4 +36,5 @@ data class AlertCheckLogEntity(
      * This is nullable because the alert might be triggered by threshold set (e.g. battery level)
      */
     @ColumnInfo(name = "notifier_type") val notifierType: NotifierType?,
+    @ColumnInfo(name = "alert_mode", defaultValue = "'THRESHOLD'") val alertMode: AlertMode = AlertMode.THRESHOLD,
 )

--- a/app/src/main/java/dev/hossain/remotenotify/db/AppDatabase.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/db/AppDatabase.kt
@@ -12,7 +12,7 @@ import androidx.room.RoomDatabase
  */
 @Database(
     entities = [AlertConfigEntity::class, AlertCheckLogEntity::class],
-    version = 3,
+    version = 4,
     exportSchema = true,
     // https://developer.android.com/training/data-storage/room/migrating-db-versions
     // https://github.com/hossain-khan/android-weather-alert/issues/272#issuecomment-2629512823
@@ -20,6 +20,7 @@ import androidx.room.RoomDatabase
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
+        AutoMigration(from = 3, to = 4),
     ],
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/dev/hossain/remotenotify/model/AlertCheckLog.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/model/AlertCheckLog.kt
@@ -14,6 +14,7 @@ data class AlertCheckLog(
     val configBatteryPercentage: Int,
     val configStorageMinSpaceGb: Int,
     val configCreatedOn: Long,
+    val alertMode: AlertMode = AlertMode.THRESHOLD,
 )
 
 fun AlertCheckLogEntity.toAlertCheckLog(): AlertCheckLog =
@@ -27,6 +28,7 @@ fun AlertCheckLogEntity.toAlertCheckLog(): AlertCheckLog =
         configBatteryPercentage = 0,
         configStorageMinSpaceGb = 0,
         configCreatedOn = 0,
+        alertMode = alertMode,
     )
 
 fun AlertLogWithConfig.toAlertCheckLog(): AlertCheckLog =
@@ -40,4 +42,5 @@ fun AlertLogWithConfig.toAlertCheckLog(): AlertCheckLog =
         configBatteryPercentage = config.batteryPercentage,
         configStorageMinSpaceGb = config.storageMinSpaceGb,
         configCreatedOn = config.createdOn,
+        alertMode = log.alertMode,
     )

--- a/app/src/main/java/dev/hossain/remotenotify/model/DeviceAlert.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/model/DeviceAlert.kt
@@ -28,11 +28,12 @@ data class DeviceAlert(
     val availableStorageGb: Double? = null,
     /** The storage threshold in Gigabytes (GB) that triggered this alert. Null if not applicable to storage alerts. */
     val storageThresholdGb: Double? = null,
-    /** Whether this is a scheduled status report rather than a threshold-triggered alert. */
-    val isStatusReport: Boolean = false,
+    /** The mode under which the alert was triggered. */
+    val alertMode: AlertMode = AlertMode.THRESHOLD,
     /** The timestamp when the alert was generated. Defaults to the current time. */
     val timestamp: LocalDateTime = LocalDateTime.now(),
 ) {
+    internal val isStatusReport: Boolean get() = alertMode == AlertMode.PERIODIC
     /**
      * Formats the device alert information into a string representation based on the specified format type.
      *
@@ -74,6 +75,7 @@ data class DeviceAlert(
                 batteryThresholdPercent = batteryThresholdPercent,
                 availableStorageGb = availableStorageGb,
                 storageThresholdGb = storageThresholdGb,
+                alertMode = alertMode,
                 isoDateTime = timestamp.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
             )
         return payload.toJson()

--- a/app/src/main/java/dev/hossain/remotenotify/model/DeviceAlertJsonPayload.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/model/DeviceAlertJsonPayload.kt
@@ -47,6 +47,8 @@ data class DeviceAlertJsonPayload constructor(
     val availableStorageGb: Double? = null,
     @SerialName("storageThresholdGb")
     val storageThresholdGb: Double? = null,
+    @SerialName("alertMode")
+    val alertMode: AlertMode = AlertMode.THRESHOLD,
     @SerialName("isoDateTime")
     val isoDateTime: String,
 ) {

--- a/app/src/main/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorker.kt
+++ b/app/src/main/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorker.kt
@@ -113,8 +113,8 @@ class ObserveDeviceHealthWorker(
     private suspend fun wasThresholdAlertSentRecently(userConfiguredAlert: RemoteAlert): Boolean {
         val lastAlertLog: AlertCheckLog? = repository.getLatestCheckForAlert(userConfiguredAlert.alertId).first()
 
-        // Skip if last alert was triggered within 24 hours
-        if (lastAlertLog?.isAlertSent == true) {
+        // Skip if last alert was triggered within 24 hours AND it was a threshold-triggered alert
+        if (lastAlertLog?.isAlertSent == true && lastAlertLog.alertMode == AlertMode.THRESHOLD) {
             val hoursSinceLastAlert = (System.currentTimeMillis() - lastAlertLog.checkedOn) / (1000 * 60 * 60)
             if (hoursSinceLastAlert < 24) {
                 // NOTE: This is to avoid spamming threshold notifications.
@@ -138,7 +138,7 @@ class ObserveDeviceHealthWorker(
             sendNotification(userConfiguredAlert, alertType, stateValue)
         } else {
             Timber.tag(WORKER_LOG_TAG).d("Notification threshold not met. Not sending: $userConfiguredAlert for $alertType")
-            saveAlertCheckLog(userConfiguredAlert.alertId, alertType, stateValue, false, null)
+            saveAlertCheckLog(userConfiguredAlert.alertId, alertType, stateValue, false, null, userConfiguredAlert.alertMode)
         }
     }
 
@@ -158,7 +158,7 @@ class ObserveDeviceHealthWorker(
             .forEach { notifier ->
                 if (remoteAlert.alertMode == AlertMode.PERIODIC && notifier.notifierType == NotifierType.EMAIL) {
                     Timber.tag(WORKER_LOG_TAG).i("Skipping EMAIL notification for PERIODIC alert due to daily quota limit")
-                    saveAlertCheckLog(remoteAlert.alertId, alertType, stateValue, false, notifier.notifierType)
+                    saveAlertCheckLog(remoteAlert.alertId, alertType, stateValue, false, notifier.notifierType, remoteAlert.alertMode)
                     return@forEach
                 }
 
@@ -199,7 +199,7 @@ class ObserveDeviceHealthWorker(
                             // Log when alert is failed to send
                             analytics.logWorkFailed(notifier.notifierType, error)
                         }.onSuccess {
-                            saveAlertCheckLog(remoteAlert.alertId, alertType, stateValue, true, notifier.notifierType)
+                            saveAlertCheckLog(remoteAlert.alertId, alertType, stateValue, true, notifier.notifierType, remoteAlert.alertMode)
                             Timber.tag(WORKER_LOG_TAG).d("Notifier status: $it")
 
                             // Log when alert is successfully sent
@@ -221,6 +221,7 @@ class ObserveDeviceHealthWorker(
         stateValue: Int,
         alertSent: Boolean,
         notifierType: NotifierType?,
+        alertMode: AlertMode = AlertMode.THRESHOLD,
     ) {
         Timber.tag(WORKER_LOG_TAG).i("Saving alert check log for $alertId")
         repository.insertAlertCheckLog(
@@ -229,6 +230,7 @@ class ObserveDeviceHealthWorker(
             alertStateValue = stateValue,
             alertTriggered = alertSent,
             notifierType = notifierType,
+            alertMode = alertMode,
         )
     }
 }

--- a/app/src/test/java/dev/hossain/remotenotify/db/AlertCheckLogDaoTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/db/AlertCheckLogDaoTest.kt
@@ -1,0 +1,112 @@
+package dev.hossain.remotenotify.db
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import dev.hossain.remotenotify.model.AlertType
+import dev.hossain.remotenotify.notifier.NotifierType
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AlertCheckLogDaoTest {
+    private lateinit var database: AppDatabase
+    private lateinit var configDao: AlertConfigDao
+    private lateinit var logDao: AlertCheckLogDao
+
+    @Before
+    fun setup() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        configDao = database.notificationDao()
+        logDao = database.alertCheckLogDao()
+
+        val config = AlertConfigEntity(
+            id = 1L,
+            type = AlertType.BATTERY,
+            batteryPercentage = 15,
+            storageMinSpaceGb = 0,
+            createdOn = 1000L
+        )
+        configDao.insert(config)
+    }
+
+    @After
+    fun teardown() {
+        database.close()
+    }
+
+    @Test
+    fun `getLatestCheckLog prioritizes triggered alert over skipped check when timestamps match regardless of insertion order`() = runTest {
+        val timestamp = 5000L
+
+        // Insert skipped check first
+        logDao.insert(
+            AlertCheckLogEntity(
+                alertConfigId = 1L,
+                checkedAt = timestamp,
+                alertStateValue = 80,
+                alertTriggered = false,
+                alertType = AlertType.BATTERY,
+                notifierType = NotifierType.EMAIL
+            )
+        )
+
+        // Insert triggered alert second
+        logDao.insert(
+            AlertCheckLogEntity(
+                alertConfigId = 1L,
+                checkedAt = timestamp,
+                alertStateValue = 80,
+                alertTriggered = true,
+                alertType = AlertType.BATTERY,
+                notifierType = NotifierType.TELEGRAM
+            )
+        )
+
+        val latestLog = logDao.getLatestCheckLog().first()
+        assertThat(latestLog?.alertTriggered).isTrue()
+        assertThat(latestLog?.notifierType).isEqualTo(NotifierType.TELEGRAM)
+    }
+
+    @Test
+    fun `getLatestCheckForAlert prioritizes triggered alert over skipped check when timestamps match`() = runTest {
+        val timestamp = 5000L
+
+        // Insert skipped check first
+        logDao.insert(
+            AlertCheckLogEntity(
+                alertConfigId = 1L,
+                checkedAt = timestamp,
+                alertStateValue = 80,
+                alertTriggered = false,
+                alertType = AlertType.BATTERY,
+                notifierType = NotifierType.EMAIL
+            )
+        )
+
+        // Insert triggered alert second
+        logDao.insert(
+            AlertCheckLogEntity(
+                alertConfigId = 1L,
+                checkedAt = timestamp,
+                alertStateValue = 80,
+                alertTriggered = true,
+                alertType = AlertType.BATTERY,
+                notifierType = NotifierType.TELEGRAM
+            )
+        )
+
+        val latestLog = logDao.getLatestCheckForAlert(1L).first()
+        assertThat(latestLog?.alertTriggered).isTrue()
+        assertThat(latestLog?.notifierType).isEqualTo(NotifierType.TELEGRAM)
+    }
+}

--- a/app/src/test/java/dev/hossain/remotenotify/model/DeviceAlertJsonPayloadTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/model/DeviceAlertJsonPayloadTest.kt
@@ -109,4 +109,21 @@ class DeviceAlertJsonPayloadTest {
         assertThat(result).startsWith("{")
         assertThat(result).endsWith("}")
     }
+
+    @Test
+    fun `toJson includes alertMode`() {
+        val payload =
+            DeviceAlertJsonPayload(
+                alertType = AlertType.BATTERY,
+                deviceModel = "Google Pixel 7",
+                androidVersion = "14",
+                batteryLevel = 80,
+                alertMode = AlertMode.PERIODIC,
+                isoDateTime = "2024-03-15T14:30:45",
+            )
+
+        val result = payload.toJson()
+
+        assertThat(result).contains("\"alertMode\":\"PERIODIC\"")
+    }
 }

--- a/app/src/test/java/dev/hossain/remotenotify/model/DeviceAlertTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/model/DeviceAlertTest.kt
@@ -153,7 +153,7 @@ class DeviceAlertTest {
                 deviceModel = "Pixel 7",
                 androidVersion = "14",
                 batteryLevel = 5,
-                isStatusReport = true,
+                alertMode = AlertMode.PERIODIC,
                 timestamp = fixedTimestamp,
             )
 
@@ -210,7 +210,7 @@ class DeviceAlertTest {
                 deviceModel = "Galaxy S23",
                 androidVersion = "13",
                 availableStorageGb = 8.5,
-                isStatusReport = true,
+                alertMode = AlertMode.PERIODIC,
                 timestamp = fixedTimestamp,
             )
 
@@ -385,12 +385,13 @@ class DeviceAlertTest {
                 deviceModel = "Pixel 7",
                 androidVersion = "14",
                 batteryLevel = 80,
-                isStatusReport = true,
+                alertMode = AlertMode.PERIODIC,
                 timestamp = fixedTimestamp,
             )
 
         assertThat(alert.format(DeviceAlert.FormatType.TEXT)).contains("ℹ️ Battery Status Report")
         assertThat(alert.format(DeviceAlert.FormatType.EXTENDED_TEXT)).contains("ℹ️ Status Report: Battery")
         assertThat(alert.format(DeviceAlert.FormatType.HTML)).contains("ℹ️ Battery Status Report")
+        assertThat(alert.format(DeviceAlert.FormatType.JSON)).contains("\"alertMode\":\"PERIODIC\"")
     }
 }

--- a/app/src/test/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorkerTest.kt
+++ b/app/src/test/java/dev/hossain/remotenotify/worker/ObserveDeviceHealthWorkerTest.kt
@@ -77,7 +77,7 @@ class ObserveDeviceHealthWorkerTest {
         coEvery { analytics.logWorkSuccess() } just Runs
         coEvery { analytics.logWorkFailed(any(), any()) } just Runs
         coEvery { analytics.logAlertSent(any(), any()) } just Runs
-        coEvery { repository.insertAlertCheckLog(any(), any(), any(), any(), any()) } just Runs
+        coEvery { repository.insertAlertCheckLog(any(), any(), any(), any(), any(), any()) } just Runs
 
         // Add this to suppress errors from worker params
         every { workerParameters.runAttemptCount } returns 0
@@ -121,7 +121,7 @@ class ObserveDeviceHealthWorkerTest {
             // Then
             assertEquals(ListenableWorker.Result.success(), result)
             coVerify(exactly = 0) { notificationSender.sendNotification(any()) }
-            coVerify(exactly = 0) { repository.insertAlertCheckLog(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { repository.insertAlertCheckLog(any(), any(), any(), any(), any(), any()) }
         }
 
     @Ignore("Test has incomplete mock setup - repository.insertAlertCheckLog needs proper mocking")
@@ -198,7 +198,7 @@ class ObserveDeviceHealthWorkerTest {
             assertEquals(ListenableWorker.Result.success(), result)
             coVerify { notificationSender.sendNotification(statusAlert) }
             coVerify(exactly = 0) { repository.getLatestCheckForAlert(any()) }
-            coVerify { repository.insertAlertCheckLog(1L, AlertType.BATTERY, 80, true, NotifierType.TELEGRAM) }
+            coVerify { repository.insertAlertCheckLog(1L, AlertType.BATTERY, 80, true, NotifierType.TELEGRAM, AlertMode.PERIODIC) }
         }
 
     @Test
@@ -223,7 +223,7 @@ class ObserveDeviceHealthWorkerTest {
             // Then
             assertEquals(ListenableWorker.Result.success(), result)
             coVerify(exactly = 0) { notificationSender.sendNotification(any()) }
-            coVerify { repository.insertAlertCheckLog(1L, AlertType.BATTERY, 80, false, NotifierType.EMAIL) }
+            coVerify { repository.insertAlertCheckLog(1L, AlertType.BATTERY, 80, false, NotifierType.EMAIL, AlertMode.PERIODIC) }
         }
 
     @Ignore("Test has incomplete mock setup - repository.insertAlertCheckLog needs proper mocking")
@@ -248,7 +248,7 @@ class ObserveDeviceHealthWorkerTest {
             // Then
             assertEquals(ListenableWorker.Result.success(), result)
             coVerify(exactly = 0) { notificationSender.sendNotification(any()) }
-            coVerify(exactly = 1) { repository.insertAlertCheckLog(2L, AlertType.STORAGE, 10, false, null) }
+            coVerify(exactly = 1) { repository.insertAlertCheckLog(2L, AlertType.STORAGE, 10, false, null, AlertMode.THRESHOLD) }
         }
 
     @Test
@@ -280,6 +280,7 @@ class ObserveDeviceHealthWorkerTest {
                     alertStateValue = 8,
                     alertTriggered = true,
                     notifierType = NotifierType.EMAIL,
+                    alertMode = AlertMode.THRESHOLD
                 )
             }
         }
@@ -308,7 +309,7 @@ class ObserveDeviceHealthWorkerTest {
             assertEquals(ListenableWorker.Result.success(), result)
             coVerify { notificationSender.sendNotification(statusAlert) }
             coVerify(exactly = 0) { repository.getLatestCheckForAlert(any()) }
-            coVerify { repository.insertAlertCheckLog(2L, AlertType.STORAGE, 42, true, NotifierType.TELEGRAM) }
+            coVerify { repository.insertAlertCheckLog(2L, AlertType.STORAGE, 42, true, NotifierType.TELEGRAM, AlertMode.PERIODIC) }
         }
 
     @Test
@@ -346,7 +347,7 @@ class ObserveDeviceHealthWorkerTest {
             // Then
             assertEquals(ListenableWorker.Result.success(), result)
             coVerify(exactly = 0) { notificationSender.sendNotification(any()) }
-            coVerify(exactly = 0) { repository.insertAlertCheckLog(any(), any(), any(), any(), any()) }
+            coVerify(exactly = 0) { repository.insertAlertCheckLog(any(), any(), any(), any(), any(), any()) }
         }
 
     @Test
@@ -386,6 +387,46 @@ class ObserveDeviceHealthWorkerTest {
             assertEquals(ListenableWorker.Result.success(), result)
             coVerify { notificationSender.sendNotification(triggeredAlert) }
             coVerify { repository.insertAlertCheckLog(1L, AlertType.BATTERY, 15, true, NotifierType.EMAIL) }
+        }
+
+    @Test
+    fun `doWork notifies threshold alert when prior periodic alert was sent within 24 hours`() =
+        runTest {
+            // Given
+            val batteryAlert =
+                RemoteAlert.BatteryAlert(
+                    alertId = 1L,
+                    batteryPercentage = 20,
+                    alertMode = AlertMode.THRESHOLD,
+                )
+
+            val currentTime = System.currentTimeMillis()
+            val alertLog =
+                AlertCheckLog(
+                    checkedOn = currentTime - (2 * 60 * 60 * 1000), // 2 hours ago (less than 24)
+                    alertType = AlertType.BATTERY,
+                    isAlertSent = true,
+                    notifierType = NotifierType.EMAIL,
+                    stateValue = 15,
+                    configId = 1L,
+                    configBatteryPercentage = 20,
+                    configStorageMinSpaceGb = 0,
+                    configCreatedOn = currentTime - (30 * 24 * 60 * 60 * 1000),
+                    alertMode = AlertMode.PERIODIC,
+                )
+
+            coEvery { repository.getAllRemoteAlert() } returns listOf(batteryAlert)
+            every { batteryMonitor.getBatteryLevel() } returns 15 // Below threshold
+            every { storageMonitor.getAvailableStorageInGB() } returns 20L
+            coEvery { repository.getLatestCheckForAlert(1L) } returns flowOf(alertLog)
+
+            // When
+            val result = worker.doWork()
+
+            // Then
+            val triggeredAlert = batteryAlert.copy(currentBatteryLevel = 15)
+            assertEquals(ListenableWorker.Result.success(), result)
+            coVerify { notificationSender.sendNotification(triggeredAlert) }
         }
 
     @Test
@@ -479,7 +520,7 @@ class ObserveDeviceHealthWorkerTest {
             coEvery { repository.getLatestCheckForAlert(1L) } returns flowOf(null)
 
             // Mock the saveAlertCheckLog method since it's referenced in the success path
-            coEvery { repository.insertAlertCheckLog(any(), any(), any(), any(), any()) } returns Unit
+            coEvery { repository.insertAlertCheckLog(any(), any(), any(), any(), any(), any()) } returns Unit
 
             // When
             worker.doWork()


### PR DESCRIPTION
## Summary
Addresses Issue #453 by hardening periodic status report logging, exposing `alertMode` in webhook payloads, and ensuring accurate rate limiting between threshold alerts and periodic reports.

## Key Changes
- **Database Schema & Query Prioritization**:
  - Added `alertMode` column to `AlertCheckLogEntity` and upgraded Room database schema to version 4 with automated migration (`AutoMigration(from = 3, to = 4)`).
  - Updated DAO query (`getLatestCheckForAlert`) to order by `checked_at DESC, is_alert_triggered DESC`, ensuring triggered threshold alerts are prioritized over simultaneous periodic log checks.
- **Worker & Rate Limiting**:
  - Updated `ObserveDeviceHealthWorker` to log and store `alertMode` across all checks.
  - Refined `wasThresholdAlertSentRecently` to ensure that periodic status reports logged within the last 24 hours do not prevent genuine threshold alerts from notifying the user.
- **Webhook Payload (`alertMode`)**:
  - Replaced `isStatusReport` with `alertMode: AlertMode = AlertMode.THRESHOLD` in `DeviceAlertJsonPayload` and `DeviceAlert`.
- **Testing (TDD Approach)**:
  - Added comprehensive unit tests for DAO query sorting, worker rate limiting interactions, and JSON payload serialization (`AlertCheckLogDaoTest`, `ObserveDeviceHealthWorkerTest`, `DeviceAlertJsonPayloadTest`, `DeviceAlertTest`).